### PR TITLE
feat(mariland): add checkbox to hide descartados pisos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,3 +10,7 @@ Los archivos de contexto están en `.ai/`:
 - `.ai/environments.md` — entornos local, producción y CI
 
 Lee estos archivos al inicio de cada sesión para tener contexto del proyecto.
+
+## Reglas críticas
+
+- **NUNCA ejecutar `pnpm`, `uv`, `pytest`, `ruff`, `mypy`, `eslint` directamente en el host.** Usar siempre `make <target> APP=<app>` — los comandos corren dentro de Docker. Ver `.ai/environments.md`.

--- a/frontend/mariland/src/App.tsx
+++ b/frontend/mariland/src/App.tsx
@@ -23,6 +23,7 @@ export default function App() {
   const [search, setSearch] = useState('')
   const [estadoFilter, setEstadoFilter] = useState('')
   const [barrioFilter, setBarrioFilter] = useState('')
+  const [hideDescartados, setHideDescartados] = useState(true)
 
   const barrios = [...new Set(pisos.map((p) => p.barrio).filter((b): b is string => b != null))].sort()
 
@@ -34,7 +35,8 @@ export default function App() {
       || (p.barrio ?? '').toLowerCase().includes(q)
     const matchEstado = !estadoFilter || p.estado === estadoFilter
     const matchBarrio = !barrioFilter || p.barrio === barrioFilter
-    return matchSearch && matchEstado && matchBarrio
+    const matchDescartados = !hideDescartados || estadoFilter === 'descartado' || p.estado !== 'descartado'
+    return matchSearch && matchEstado && matchBarrio && matchDescartados
   })
 
   async function handleCreate(data: PisoCreate | PisoUpdate) {
@@ -85,6 +87,7 @@ export default function App() {
           estadoFilter={estadoFilter} setEstadoFilter={setEstadoFilter}
           barrioFilter={barrioFilter} setBarrioFilter={setBarrioFilter}
           barrios={barrios}
+          hideDescartados={hideDescartados} setHideDescartados={setHideDescartados}
         />
 
         {loading && <p className="text-center text-gray-500 py-12">Cargando pisos...</p>}

--- a/frontend/mariland/src/components/Filters.tsx
+++ b/frontend/mariland/src/components/Filters.tsx
@@ -8,6 +8,8 @@ interface FiltersProps {
   barrioFilter: string
   setBarrioFilter: (v: string) => void
   barrios: string[]
+  hideDescartados: boolean
+  setHideDescartados: (v: boolean) => void
 }
 
 export default function Filters({
@@ -18,6 +20,8 @@ export default function Filters({
   barrioFilter,
   setBarrioFilter,
   barrios,
+  hideDescartados,
+  setHideDescartados,
 }: FiltersProps) {
   return (
     <div className="flex flex-wrap items-center gap-3">
@@ -43,6 +47,15 @@ export default function Filters({
         <option value="">Todos los barrios</option>
         {barrios.map((b) => <option key={b} value={b}>{b}</option>)}
       </select>
+      <label className="flex items-center gap-2 text-sm text-gray-600 cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={hideDescartados}
+          onChange={(e) => setHideDescartados(e.target.checked)}
+          className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+        />
+        Ocultar descartados
+      </label>
     </div>
   )
 }

--- a/frontend/mariland/src/test/Filters.test.tsx
+++ b/frontend/mariland/src/test/Filters.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import Filters from '../components/Filters'
+
+function renderFilters(overrides: { hideDescartados?: boolean } = {}) {
+  const props = {
+    search: '',
+    setSearch: vi.fn(),
+    estadoFilter: '',
+    setEstadoFilter: vi.fn(),
+    barrioFilter: '',
+    setBarrioFilter: vi.fn(),
+    barrios: [],
+    hideDescartados: overrides.hideDescartados ?? true,
+    setHideDescartados: vi.fn(),
+  }
+  render(<Filters {...props} />)
+  return props
+}
+
+describe('Filters - hideDescartados checkbox', () => {
+  it('renders the ocultar descartados checkbox', () => {
+    renderFilters()
+    expect(screen.getByRole('checkbox', { name: /ocultar descartados/i })).toBeInTheDocument()
+  })
+
+  it('checkbox is checked by default', () => {
+    renderFilters({ hideDescartados: true })
+    expect(screen.getByRole('checkbox', { name: /ocultar descartados/i })).toBeChecked()
+  })
+
+  it('checkbox is unchecked when hideDescartados is false', () => {
+    renderFilters({ hideDescartados: false })
+    expect(screen.getByRole('checkbox', { name: /ocultar descartados/i })).not.toBeChecked()
+  })
+
+  it('calls setHideDescartados(false) when unchecking', async () => {
+    const user = userEvent.setup()
+    const props = renderFilters({ hideDescartados: true })
+
+    await user.click(screen.getByRole('checkbox', { name: /ocultar descartados/i }))
+
+    expect(props.setHideDescartados).toHaveBeenCalledWith(false)
+  })
+
+  it('calls setHideDescartados(true) when checking', async () => {
+    const user = userEvent.setup()
+    const props = renderFilters({ hideDescartados: false })
+
+    await user.click(screen.getByRole('checkbox', { name: /ocultar descartados/i }))
+
+    expect(props.setHideDescartados).toHaveBeenCalledWith(true)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a checkbox "Ocultar descartados" en la barra de filtros, marcado por defecto
- Los pisos con `estado=descartado` se ocultan al cargar la página
- Si el dropdown de estado está puesto en "descartado", el checkbox no interfiere (se muestran igualmente)

## Changes
- `Filters.tsx` — nuevo prop `hideDescartados`/`setHideDescartados` + checkbox en la UI
- `App.tsx` — estado `hideDescartados` (default `true`) + lógica de filtrado
- `Filters.test.tsx` — tests nuevos para el checkbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)