### PR TITLE
fix(mariland): show inmobiliaria in piso card

### DIFF
--- a/frontend/mariland/src/components/PisoCard.tsx
+++ b/frontend/mariland/src/components/PisoCard.tsx
@@ -101,7 +101,7 @@ export default function PisoCard({ piso, onEdit, onDelete, onComments, onPrices,
 
       {piso.notas && <p className="mt-2 text-sm text-gray-500 italic truncate">{piso.notas}</p>}
 
-      {(piso.contacto_nombre ?? piso.contacto_telefono) && (
+      {(piso.contacto_nombre ?? piso.contacto_telefono ?? piso.contacto_inmobiliaria) && (
         <div className="mt-3 flex items-center gap-2 text-xs text-gray-500">
           <span>{piso.contacto_inmobiliaria ? '🏢' : '👤'}</span>
           {piso.contacto_nombre && <span className="font-medium">{piso.contacto_nombre}</span>}


### PR DESCRIPTION
## Summary
- La sección de contacto en las cards de pisos ahora se muestra cuando solo hay inmobiliaria, sin necesidad de nombre o teléfono de contacto

## Context
El campo `contacto_inmobiliaria` no aparecía en la card si `contacto_nombre` y `contacto_telefono` estaban vacíos, porque la condición de visibilidad no lo incluía.

## Changes
- `PisoCard.tsx`: añadido `piso.contacto_inmobiliaria` a la condición que controla la visibilidad del bloque de contacto

## Test Plan
1. Ir al entorno de preview
2. Abrir/editar un piso que tenga inmobiliaria pero sin nombre ni teléfono de contacto
3. Verificar que la inmobiliaria aparece en la card

🤖 Generated with [Claude Code](https://claude.com/claude-code)