### PR TITLE
feat(mariland): add contactado and agendado estados

### DIFF
--- a/frontend/mariland/src/components/Filters.tsx
+++ b/frontend/mariland/src/components/Filters.tsx
@@ -1,4 +1,4 @@
-const ESTADOS = ['candidato', 'visitado', 'descartado', 'oferta', 'comprado']
+const ESTADOS = ['candidato', 'contactado', 'agendado', 'visitado', 'descartado', 'oferta', 'comprado']
 
 interface FiltersProps {
   search: string

--- a/frontend/mariland/src/components/PisoCard.tsx
+++ b/frontend/mariland/src/components/PisoCard.tsx
@@ -3,6 +3,8 @@ import ActionMenu from './ActionMenu'
 
 const ESTADO_COLORS: Record<string, string> = {
   candidato: 'bg-blue-100 text-blue-700',
+  contactado: 'bg-orange-100 text-orange-700',
+  agendado: 'bg-teal-100 text-teal-700',
   visitado: 'bg-purple-100 text-purple-700',
   descartado: 'bg-gray-100 text-gray-500',
   oferta: 'bg-yellow-100 text-yellow-700',

--- a/frontend/mariland/src/components/PisoForm.tsx
+++ b/frontend/mariland/src/components/PisoForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import type { Piso, PisoCreate, PisoUpdate } from '../types/piso'
 import Modal from './Modal'
 
-const ESTADOS = ['candidato', 'visitado', 'descartado', 'oferta', 'comprado']
+const ESTADOS = ['candidato', 'contactado', 'agendado', 'visitado', 'descartado', 'oferta', 'comprado']
 const CERT_ENERGETICA = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'en trámite', 'exento']
 const ORIENTACIONES = ['Norte', 'Noreste', 'Este', 'Sureste', 'Sur', 'Suroeste', 'Oeste', 'Noroeste']
 const BARRIOS = [

--- a/frontend/mariland/src/test/Filters.test.tsx
+++ b/frontend/mariland/src/test/Filters.test.tsx
@@ -53,3 +53,15 @@ describe('Filters - hideDescartados checkbox', () => {
     expect(props.setHideDescartados).toHaveBeenCalledWith(true)
   })
 })
+
+describe('Filters - estado dropdown options', () => {
+  it('includes contactado option in estado dropdown', () => {
+    renderFilters()
+    expect(screen.getByRole('option', { name: 'contactado' })).toBeInTheDocument()
+  })
+
+  it('includes agendado option in estado dropdown', () => {
+    renderFilters()
+    expect(screen.getByRole('option', { name: 'agendado' })).toBeInTheDocument()
+  })
+})

--- a/frontend/mariland/src/test/PisoCard.test.tsx
+++ b/frontend/mariland/src/test/PisoCard.test.tsx
@@ -81,4 +81,14 @@ describe('PisoCard', () => {
     })
     expect(screen.getByText('💬 1')).toBeInTheDocument()
   })
+
+  it('renders badge for estado contactado', () => {
+    renderCard({ estado: 'contactado' })
+    expect(screen.getByText('contactado')).toBeInTheDocument()
+  })
+
+  it('renders badge for estado agendado', () => {
+    renderCard({ estado: 'agendado' })
+    expect(screen.getByText('agendado')).toBeInTheDocument()
+  })
 })

--- a/frontend/mariland/src/test/Stats.test.tsx
+++ b/frontend/mariland/src/test/Stats.test.tsx
@@ -65,4 +65,18 @@ describe('Stats', () => {
     expect(screen.getByText('candidato')).toBeInTheDocument()
     expect(screen.getByText('visitado')).toBeInTheDocument()
   })
+
+  it('renders contactado in estado breakdown', () => {
+    render(<Stats pisos={[
+      makePiso({ estado: 'contactado' }),
+    ]} />)
+    expect(screen.getByText('contactado')).toBeInTheDocument()
+  })
+
+  it('renders agendado in estado breakdown', () => {
+    render(<Stats pisos={[
+      makePiso({ estado: 'agendado' }),
+    ]} />)
+    expect(screen.getByText('agendado')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- Añade dos estados intermedios entre `candidato` y `visitado`: `contactado` y `agendado`
- Nuevo flujo: `candidato → contactado → agendado → visitado → descartado → oferta → comprado`
- Sin cambios en backend ni migraciones (campo `estado` es `String(64)` sin enum)

## Changes
- `PisoCard`: colores para los nuevos estados (naranja para `contactado`, teal para `agendado`)
- `PisoForm` y `Filters`: arrays `ESTADOS` actualizados con los nuevos valores en el orden correcto
- Tests para los nuevos estados en `PisoCard.test.tsx`, `Filters.test.tsx` y `Stats.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)