### PR TITLE
feat(mariland): add imagen_url thumbnail banner with full-size modal

### DIFF
--- a/backend/mariland/alembic/versions/0002_add_imagen_url_to_pisos.py
+++ b/backend/mariland/alembic/versions/0002_add_imagen_url_to_pisos.py
@@ -1,0 +1,25 @@
+"""add imagen_url to pisos
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-03-21
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("pisos", sa.Column("imagen_url", sa.String(2048), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("pisos", "imagen_url")

--- a/backend/mariland/src/app/domain/models/piso.py
+++ b/backend/mariland/src/app/domain/models/piso.py
@@ -10,6 +10,7 @@ from app.domain.models.price_history import PriceHistory
 class Piso(BaseModel):
     id: int
     url: str | None
+    imagen_url: str | None
     direccion: str | None
     barrio: str | None
     precio: int | None

--- a/backend/mariland/src/app/infrastructure/persistence/models.py
+++ b/backend/mariland/src/app/infrastructure/persistence/models.py
@@ -13,6 +13,7 @@ class PisoModel(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    imagen_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     direccion: Mapped[str | None] = mapped_column(String(512), nullable=True)
     barrio: Mapped[str | None] = mapped_column(String(256), nullable=True)
     precio: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -30,9 +31,7 @@ class PisoModel(Base):
     estado: Mapped[str] = mapped_column(String(64), nullable=False, default="candidato")
     extras: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True, default=dict)
     notas: Mapped[str | None] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
@@ -60,9 +59,7 @@ class PriceHistoryModel(Base):
     )
     precio: Mapped[int] = mapped_column(Integer, nullable=False)
     notas: Mapped[str | None] = mapped_column(Text, nullable=True)
-    fecha: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    fecha: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     piso: Mapped["PisoModel"] = relationship("PisoModel", back_populates="price_history")
 
@@ -75,8 +72,6 @@ class CommentModel(Base):
         Integer, ForeignKey("pisos.id", ondelete="CASCADE"), nullable=False
     )
     texto: Mapped[str] = mapped_column(Text, nullable=False)
-    fecha: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
+    fecha: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     piso: Mapped["PisoModel"] = relationship("PisoModel", back_populates="comments")

--- a/backend/mariland/src/app/presentation/schemas/piso_schemas.py
+++ b/backend/mariland/src/app/presentation/schemas/piso_schemas.py
@@ -34,6 +34,7 @@ class CommentOut(BaseModel):
 
 class PisoCreate(BaseModel):
     url: str | None = None
+    imagen_url: str | None = None
     direccion: str | None = None
     barrio: str | None = None
     precio: int | None = None
@@ -55,6 +56,7 @@ class PisoCreate(BaseModel):
 
 class PisoUpdate(BaseModel):
     url: str | None = None
+    imagen_url: str | None = None
     direccion: str | None = None
     barrio: str | None = None
     precio: int | None = None
@@ -77,6 +79,7 @@ class PisoUpdate(BaseModel):
 class PisoOut(BaseModel):
     id: int
     url: str | None
+    imagen_url: str | None
     direccion: str | None
     barrio: str | None
     precio: int | None

--- a/backend/mariland/tests/conftest.py
+++ b/backend/mariland/tests/conftest.py
@@ -22,6 +22,7 @@ def make_piso(**kwargs: Any) -> Piso:
     defaults: dict[str, Any] = {
         "id": 1,
         "url": None,
+        "imagen_url": None,
         "direccion": "Calle Falsa 123",
         "barrio": "Centre",
         "precio": 250000,

--- a/backend/mariland/tests/e2e/test_pisos_api.py
+++ b/backend/mariland/tests/e2e/test_pisos_api.py
@@ -98,9 +98,7 @@ async def test_update_piso(async_client: AsyncClient, mock_piso_svc: AsyncMock) 
     piso = make_piso(id=1, estado="visitado", precio=190000)
     mock_piso_svc.update_piso.return_value = piso
 
-    response = await async_client.put(
-        "/api/pisos/1", json={"estado": "visitado", "precio": 190000}
-    )
+    response = await async_client.put("/api/pisos/1", json={"estado": "visitado", "precio": 190000})
 
     assert response.status_code == 200
     assert response.json()["estado"] == "visitado"
@@ -155,3 +153,33 @@ async def test_delete_price(async_client: AsyncClient, mock_price_svc: AsyncMock
     response = await async_client.delete("/api/pisos/1/prices/1")
 
     assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_create_piso_with_imagen_url(
+    async_client: AsyncClient, mock_piso_svc: AsyncMock
+) -> None:
+    piso = make_piso(id=1, imagen_url="https://example.com/foto.jpg")
+    mock_piso_svc.create_piso.return_value = piso
+
+    response = await async_client.post(
+        "/api/pisos/",
+        json={"estado": "candidato", "imagen_url": "https://example.com/foto.jpg"},
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["imagen_url"] == "https://example.com/foto.jpg"
+
+
+@pytest.mark.asyncio
+async def test_piso_out_contains_imagen_url_null(
+    async_client: AsyncClient, mock_piso_svc: AsyncMock
+) -> None:
+    piso = make_piso(id=2, imagen_url=None)
+    mock_piso_svc.get_piso.return_value = piso
+
+    response = await async_client.get("/api/pisos/2")
+
+    assert response.status_code == 200
+    assert response.json()["imagen_url"] is None

--- a/backend/mariland/tests/integration/test_piso_repository.py
+++ b/backend/mariland/tests/integration/test_piso_repository.py
@@ -61,3 +61,27 @@ async def test_get_nonexistent_piso(db_session: AsyncSession) -> None:
     repo = SQLAlchemyPisoRepository(db_session)
     fetched = await repo.get_by_id(99999)
     assert fetched is None
+
+
+@pytest.mark.asyncio
+async def test_create_piso_with_imagen_url(db_session: AsyncSession) -> None:
+    repo = SQLAlchemyPisoRepository(db_session)
+
+    piso = await repo.create({"estado": "candidato", "imagen_url": "https://foto.com/1.jpg"})
+
+    assert piso.imagen_url == "https://foto.com/1.jpg"
+
+    fetched = await repo.get_by_id(piso.id)
+    assert fetched is not None
+    assert fetched.imagen_url == "https://foto.com/1.jpg"
+
+
+@pytest.mark.asyncio
+async def test_update_piso_imagen_url(db_session: AsyncSession) -> None:
+    repo = SQLAlchemyPisoRepository(db_session)
+
+    piso = await repo.create({"estado": "candidato"})
+    updated = await repo.update(piso.id, {"imagen_url": "https://nueva.com/img.jpg"})
+
+    assert updated is not None
+    assert updated.imagen_url == "https://nueva.com/img.jpg"

--- a/backend/mariland/tests/unit/test_piso_service.py
+++ b/backend/mariland/tests/unit/test_piso_service.py
@@ -24,9 +24,7 @@ async def test_list_pisos(service: PisoService, mock_piso_repository: AsyncMock)
 
 
 @pytest.mark.asyncio
-async def test_get_piso_returns_piso(
-    service: PisoService, mock_piso_repository: AsyncMock
-) -> None:
+async def test_get_piso_returns_piso(service: PisoService, mock_piso_repository: AsyncMock) -> None:
     piso = make_piso(id=42, direccion="Gran Via 1")
     mock_piso_repository.get_by_id.return_value = piso
 
@@ -99,3 +97,36 @@ async def test_delete_piso_raises_not_found(
 
     with pytest.raises(NotFoundError):
         await service.delete_piso(999)
+
+
+@pytest.mark.asyncio
+async def test_create_piso_with_imagen_url(
+    service: PisoService, mock_piso_repository: AsyncMock
+) -> None:
+    piso = make_piso(imagen_url="https://example.com/foto.jpg")
+    mock_piso_repository.create.return_value = piso
+
+    data = {
+        "direccion": "Calle Falsa 123",
+        "estado": "candidato",
+        "imagen_url": "https://example.com/foto.jpg",
+    }
+    result = await service.create_piso(data)
+
+    assert result.imagen_url == "https://example.com/foto.jpg"
+    mock_piso_repository.create.assert_awaited_once_with(data)
+
+
+@pytest.mark.asyncio
+async def test_update_piso_imagen_url(
+    service: PisoService, mock_piso_repository: AsyncMock
+) -> None:
+    piso = make_piso(imagen_url="https://nueva.com/img.jpg")
+    mock_piso_repository.update.return_value = piso
+
+    result = await service.update_piso(1, {"imagen_url": "https://nueva.com/img.jpg"})
+
+    assert result.imagen_url == "https://nueva.com/img.jpg"
+    mock_piso_repository.update.assert_awaited_once_with(
+        1, {"imagen_url": "https://nueva.com/img.jpg"}
+    )

--- a/frontend/mariland/.claude/plans/imagen-thumbnail.md
+++ b/frontend/mariland/.claude/plans/imagen-thumbnail.md
@@ -1,0 +1,149 @@
+# Plan: Añadir campo `imagen_url` con thumbnail en PisoCard
+
+## Descripción
+
+Añadir un campo `imagen_url` (URL externa) a los pisos. En la card se muestra un banner horizontal en la parte superior. Al clicar la imagen se abre un modal con la imagen en grande.
+
+---
+
+## Fase 0: Rama de trabajo
+
+- [x] Hacer checkout a `main` y pull
+- [x] Crear rama: `feature/mariland-imagen-thumbnail`
+
+---
+
+## Fase 1: Tests backend (escribir primero, deben fallar)
+
+**1.1 — Tests unitarios (`tests/unit/test_piso_service.py`)**
+
+- [x] Test `test_create_piso_with_imagen_url`: verifica que `create_piso` propaga `imagen_url` y el piso devuelto tiene el campo correcto
+- [x] Test `test_update_piso_imagen_url`: verifica que `update_piso` propaga el campo `imagen_url`
+
+**1.2 — Tests de integración (`tests/integration/test_piso_repository.py`)**
+
+- [x] Test `test_create_piso_with_imagen_url`: crea un piso con `imagen_url` via repo y verifica que se persiste y se recupera correctamente
+- [x] Test `test_update_piso_imagen_url`: actualiza un piso existente con un `imagen_url` nuevo y verifica
+
+**1.3 — Tests e2e (`tests/e2e/test_pisos_api.py`)**
+
+- [x] Test `test_create_piso_with_imagen_url`: POST con `imagen_url` en el body, verifica respuesta JSON incluye el campo con el valor correcto
+- [x] Test `test_piso_out_contains_imagen_url_null`: verifica que un piso sin imagen devuelve `"imagen_url": null`
+
+**1.4 — Ejecutar tests para confirmar que fallan**
+
+- [x] `make test-unit APP=mariland` → 2 fallan por `imagen_url` inexistente en `Piso`
+- [ ] `make test-integration APP=mariland` → pendiente (se verificará tras migración)
+- [x] `make test-e2e APP=mariland` → 2 fallan por schema incompleto
+
+---
+
+## Fase 2: Implementación backend
+
+**2.1 — Domain model (`backend/mariland/src/app/domain/models/piso.py`)**
+
+- [x] Añadir `imagen_url: str | None` después de `url`
+
+**2.2 — SQLAlchemy model (`backend/mariland/src/app/infrastructure/persistence/models.py`)**
+
+- [x] Añadir `imagen_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)` después de `url`
+
+**2.3 — Schemas (`backend/mariland/src/app/presentation/schemas/piso_schemas.py`)**
+
+- [x] `PisoCreate`: añadir `imagen_url: str | None = None`
+- [x] `PisoUpdate`: añadir `imagen_url: str | None = None`
+- [x] `PisoOut`: añadir `imagen_url: str | None`
+
+**2.4 — Migración Alembic**
+
+- [x] Crear `backend/mariland/alembic/versions/0002_add_imagen_url_to_pisos.py` con `op.add_column` / `op.drop_column`
+- [ ] Aplicar la migración: `make migrate APP=mariland` (se aplica en arranque del servidor)
+
+**2.5 — Helper `make_piso` en tests**
+
+- [x] Añadir `imagen_url: None` a los defaults del helper `make_piso` en `tests/conftest.py`
+
+**2.6 — Ejecutar tests backend completos**
+
+- [x] `make test-unit APP=mariland` → 18 passed
+- [x] `make test-integration APP=mariland` → 11 passed
+- [x] `make test-e2e APP=mariland` → 13 passed
+
+---
+
+## Fase 3: Tests frontend (escribir primero, deben fallar)
+
+**3.1 — Actualizar `basePiso` en tests existentes**
+
+- [x] `frontend/mariland/src/test/PisoCard.test.tsx`: añadir `imagen_url: null` al objeto `basePiso`
+- [x] `frontend/mariland/src/test/usePisos.test.ts`: añadir `imagen_url: null` al objeto `basePiso`
+
+**3.2 — Nuevos tests en `PisoCard.test.tsx`**
+
+- [x] Test `renders image banner when imagen_url is set`: verifica que se renderiza `<img>` con el `src` correcto
+- [x] Test `does not render image banner when imagen_url is null`: verifica que no aparece `<img>`
+- [x] Test `clicking image banner opens image modal`: clic en la imagen → aparece el modal (`role="dialog"`)
+
+**3.3 — Tests para `ImagenModal` (nuevo `src/test/ImagenModal.test.tsx`)**
+
+- [x] Test `renders the image in full size`: verifica `<img>` con el `src` correcto
+- [x] Test `calls onClose when pressing Escape`
+- [x] Test `calls onClose when clicking overlay`
+
+**3.4 — Ejecutar tests para confirmar que fallan**
+
+- [x] `make test-frontend APP=mariland` → fallaron como esperado (2 failed)
+
+---
+
+## Fase 4: Implementación frontend
+
+**4.1 — Tipos TypeScript (`frontend/mariland/src/types/piso.ts`)**
+
+- [x] Añadir `imagen_url: string | null` a `Piso`
+- [x] Añadir `imagen_url?: string | null` a `PisoCreate` / `PisoUpdate`
+
+**4.2 — Nuevo componente `ImagenModal.tsx`**
+
+- [x] Crear `frontend/mariland/src/components/ImagenModal.tsx`
+
+**4.3 — Actualizar `PisoCard.tsx`**
+
+- [x] Añadir import de `ImagenModal` y `useState`
+- [x] Añadir estado y banner de imagen con `-mx-5 -mt-5`
+- [x] Renderizar modal al final del JSX
+
+**4.4 — Actualizar `PisoForm.tsx`**
+
+- [x] Añadir `imagen_url` a `FormState`, inicialización y submit
+- [x] Añadir campo de input `type="url"` después del campo "URL del anuncio"
+
+**4.5 — Ejecutar tests frontend**
+
+- [x] `make test-frontend APP=mariland` → 31 passed
+
+---
+
+## Fase 5: Formatters, linters y typecheck
+
+- [x] `make format APP=mariland` → 6 reformatted
+- [x] `make lint APP=mariland` → all checks passed
+- [x] `make typecheck APP=mariland` → no issues found
+- [x] `make lint-frontend APP=mariland` → no warnings
+
+---
+
+## Fase 6: Verificación final
+
+- [ ] `make test APP=mariland` → todos los tests backend
+- [ ] `make test-frontend APP=mariland` → todos los tests frontend
+
+---
+
+## Fase 7: Commit y PR
+
+- [ ] Verificar usuario git: `git config user.name` → `marcslopz`
+- [ ] Stagear archivos específicos
+- [ ] Commit con `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
+- [ ] Push: `git push -u origin feature/mariland-imagen-thumbnail`
+- [ ] Crear PR con `gh pr create`

--- a/frontend/mariland/src/components/ImagenModal.tsx
+++ b/frontend/mariland/src/components/ImagenModal.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react'
+
+interface ImagenModalProps {
+  url: string
+  onClose: () => void
+}
+
+export default function ImagenModal({ url, onClose }: ImagenModalProps) {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  return (
+    <div
+      role="dialog"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+      onClick={onClose}
+    >
+      <button
+        onClick={(e) => e.stopPropagation()}
+        className="absolute right-4 top-4 rounded-full bg-white/20 p-2 text-white hover:bg-white/30"
+        aria-label="Cerrar"
+        type="button"
+      >
+        ✕
+      </button>
+      <img
+        src={url}
+        alt="Foto del piso en grande"
+        className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>
+  )
+}

--- a/frontend/mariland/src/components/PisoCard.tsx
+++ b/frontend/mariland/src/components/PisoCard.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
 import type { Piso, PriceHistory } from '../types/piso'
 import ActionMenu from './ActionMenu'
+import ImagenModal from './ImagenModal'
 
 const ESTADO_COLORS: Record<string, string> = {
   candidato: 'bg-blue-100 text-blue-700',
@@ -41,12 +43,22 @@ interface PisoCardProps {
 }
 
 export default function PisoCard({ piso, onEdit, onDelete, onComments, onPrices, onExtras }: PisoCardProps) {
+  const [showImagenModal, setShowImagenModal] = useState(false)
   const variation = priceVariation(piso)
   const precioM2 = piso.precio && piso.metros ? Math.round(piso.precio / piso.metros) : null
   const certColor = piso.certificacion_energetica ? CERT_COLORS[piso.certificacion_energetica] : undefined
 
   return (
     <div className={`rounded-2xl border bg-white p-5 shadow-sm transition hover:shadow-md ${piso.estado === 'descartado' ? 'opacity-60' : ''}`}>
+      {piso.imagen_url && (
+        <button
+          type="button"
+          onClick={() => setShowImagenModal(true)}
+          className="-mx-5 -mt-5 mb-3 block w-[calc(100%+2.5rem)] overflow-hidden rounded-t-2xl"
+        >
+          <img src={piso.imagen_url} alt="Foto del piso" className="h-40 w-full object-cover" />
+        </button>
+      )}
       <div className="mb-3 flex items-start justify-between gap-2">
         <div className="flex-1 min-w-0">
           <h3 className="truncate font-semibold text-gray-900">
@@ -124,6 +136,9 @@ export default function PisoCard({ piso, onEdit, onDelete, onComments, onPrices,
           </a>
         )}
       </div>
+      {showImagenModal && piso.imagen_url && (
+        <ImagenModal url={piso.imagen_url} onClose={() => setShowImagenModal(false)} />
+      )}
     </div>
   )
 }

--- a/frontend/mariland/src/components/PisoForm.tsx
+++ b/frontend/mariland/src/components/PisoForm.tsx
@@ -20,6 +20,7 @@ type FormState = {
   direccion: string
   barrio: string
   url: string
+  imagen_url: string
   precio: string
   habitaciones: string
   banos: string
@@ -47,6 +48,7 @@ export default function PisoForm({ piso, onSave, onClose }: PisoFormProps) {
     direccion: piso?.direccion ?? '',
     barrio: piso?.barrio ?? '',
     url: piso?.url ?? '',
+    imagen_url: piso?.imagen_url ?? '',
     precio: piso?.precio != null ? String(piso.precio) : '',
     habitaciones: piso?.habitaciones != null ? String(piso.habitaciones) : '',
     banos: piso?.banos != null ? String(piso.banos) : '',
@@ -76,6 +78,7 @@ export default function PisoForm({ piso, onSave, onClose }: PisoFormProps) {
         direccion: form.direccion || null,
         barrio: form.barrio || null,
         url: form.url || null,
+        imagen_url: form.imagen_url || null,
         precio: form.precio ? parseInt(form.precio) : null,
         habitaciones: form.habitaciones ? parseInt(form.habitaciones) : null,
         banos: form.banos ? parseInt(form.banos) : null,
@@ -124,6 +127,11 @@ export default function PisoForm({ piso, onSave, onClose }: PisoFormProps) {
         <div>
           <label className="mb-1 block text-sm font-medium text-gray-700">URL del anuncio</label>
           <input value={form.url} onChange={set('url')} type="url"
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700">URL de imagen</label>
+          <input value={form.imagen_url} onChange={set('imagen_url')} type="url" placeholder="https://..."
             className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none" />
         </div>
         <div className="grid grid-cols-3 gap-3">

--- a/frontend/mariland/src/test/ImagenModal.test.tsx
+++ b/frontend/mariland/src/test/ImagenModal.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import ImagenModal from '../components/ImagenModal'
+
+describe('ImagenModal', () => {
+  it('renders the image with the provided url', () => {
+    render(<ImagenModal url="https://example.com/foto.jpg" onClose={vi.fn()} />)
+    const img = screen.getByRole('img')
+    expect(img).toHaveAttribute('src', 'https://example.com/foto.jpg')
+  })
+
+  it('calls onClose when pressing Escape', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<ImagenModal url="https://example.com/foto.jpg" onClose={onClose} />)
+
+    await user.keyboard('{Escape}')
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when clicking the overlay', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<ImagenModal url="https://example.com/foto.jpg" onClose={onClose} />)
+
+    await user.click(screen.getByRole('dialog'))
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/mariland/src/test/PisoCard.test.tsx
+++ b/frontend/mariland/src/test/PisoCard.test.tsx
@@ -7,6 +7,7 @@ import type { Piso } from '../types/piso'
 const basePiso: Piso = {
   id: 1,
   url: null,
+  imagen_url: null,
   direccion: 'Calle Falsa 123',
   barrio: 'Centre',
   precio: 250000,
@@ -90,5 +91,25 @@ describe('PisoCard', () => {
   it('renders badge for estado agendado', () => {
     renderCard({ estado: 'agendado' })
     expect(screen.getByText('agendado')).toBeInTheDocument()
+  })
+
+  it('renders image banner when imagen_url is set', () => {
+    renderCard({ imagen_url: 'https://example.com/foto.jpg' })
+    const img = screen.getByRole('img', { name: 'Foto del piso' })
+    expect(img).toHaveAttribute('src', 'https://example.com/foto.jpg')
+  })
+
+  it('does not render image banner when imagen_url is null', () => {
+    renderCard({ imagen_url: null })
+    expect(screen.queryByRole('img', { name: 'Foto del piso' })).not.toBeInTheDocument()
+  })
+
+  it('clicking image banner opens image modal', async () => {
+    const user = userEvent.setup()
+    renderCard({ imagen_url: 'https://example.com/foto.jpg' })
+
+    await user.click(screen.getByRole('img', { name: 'Foto del piso' }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 })

--- a/frontend/mariland/src/test/Stats.test.tsx
+++ b/frontend/mariland/src/test/Stats.test.tsx
@@ -7,6 +7,7 @@ function makePiso(overrides: Partial<Piso> = {}): Piso {
   return {
     id: 1,
     url: null,
+    imagen_url: null,
     direccion: 'Test',
     barrio: null,
     precio: null,

--- a/frontend/mariland/src/test/usePisos.test.ts
+++ b/frontend/mariland/src/test/usePisos.test.ts
@@ -7,6 +7,7 @@ import type { Piso } from '../types/piso'
 const basePiso: Piso = {
   id: 1,
   url: null,
+  imagen_url: null,
   direccion: 'Calle Test 1',
   barrio: 'Centre',
   precio: 250000,

--- a/frontend/mariland/src/types/piso.ts
+++ b/frontend/mariland/src/types/piso.ts
@@ -16,6 +16,7 @@ export interface Comment {
 export interface Piso {
   id: number
   url: string | null
+  imagen_url: string | null
   direccion: string | null
   barrio: string | null
   precio: number | null
@@ -41,6 +42,7 @@ export interface Piso {
 
 export interface PisoCreate {
   url?: string | null
+  imagen_url?: string | null
   direccion?: string | null
   barrio?: string | null
   precio?: number | null


### PR DESCRIPTION
## Summary

- Añade campo `imagen_url` (URL externa) a los pisos — sin hosting, solo enlace
- `PisoCard` muestra un banner horizontal (ancho completo, 160px) en la parte superior cuando hay imagen
- Al clicar el banner se abre `ImagenModal` con la imagen a pantalla completa
- El modal se cierra con Escape o clic en el overlay
- `PisoForm` incluye un nuevo campo "URL de imagen"

## Changes

- `backend`: columna `imagen_url` en SQLAlchemy model, domain model y schemas + migración Alembic `0002`
- `frontend`: tipos actualizados, nuevo componente `ImagenModal`, banner en `PisoCard`, campo en `PisoForm`

## Testing

- 18 unit tests backend ✓
- 11 integration tests backend ✓
- 13 e2e tests backend ✓
- 31 frontend tests ✓

## Test Plan

1. Arrancar el entorno: `make up APP=mariland`
2. Crear o editar un piso y rellenar el campo **URL de imagen** con una URL de imagen válida (ej: de idealista o fotocasa)
3. Verificar que aparece el banner en la card
4. Clicar el banner → debe abrirse el modal con la imagen a pantalla completa
5. Cerrar con Escape y con clic en el overlay
6. Verificar que un piso sin `imagen_url` no muestra banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)