### PR TITLE
feat(mariland): improve import-from-URL error handling and SSE progress

### DIFF
--- a/.claude/plans/improve-import-url-error-handling.md
+++ b/.claude/plans/improve-import-url-error-handling.md
@@ -1,0 +1,89 @@
+# Improve import-from-URL error handling + progress UI
+
+## Context
+
+El endpoint `POST /pisos/from-url` puede tardar 60-120s y no da feedback de progreso. Si falla (ScrapingBee timeout, bot-block de Idealista, error de Claude), el usuario solo ve un 500 genérico. Los logs tampoco identifican claramente qué paso falló ni con qué URL.
+
+**Root cause del issue #9**: Idealista tiene protección anti-bot ("checking device...") que ScrapingBee no puede bypassear → ScrapingBee devuelve 500 → httpx no lo captura → 500 genérico al frontend. No podemos resolver el bot-block, pero sí informar claramente al usuario.
+
+## Plan
+
+### Paso 1: Excepciones de dominio granulares ✓
+**Archivo**: `backend/mariland/src/mariland/domain/exceptions.py`
+- Añadir `FetchError(ScrapingError)` — fallo en obtención de URL
+- Añadir `ExtractionError(ScrapingError)` — fallo en extracción con Claude
+
+### Paso 2: Error handling en fetchers
+**Archivos**: `infrastructure/scraping/scrapingbee_fetcher.py`, `jina_fetcher.py`
+- [ ] Capturar `httpx.ReadTimeout`, `httpx.HTTPStatusError`, `httpx.ConnectTimeout` → `FetchError` con mensaje descriptivo (URL, qué pasó)
+- [ ] ScrapingBee: subir timeout de 60s a 120s
+- [ ] Log explícito del error antes de lanzar la excepción
+
+### Paso 3: Error handling en LlmScraper._extract_fields
+**Archivo**: `infrastructure/scraping/llm_scraper.py`
+- [ ] Capturar `anthropic.APITimeoutError`, `anthropic.APIStatusError`, `anthropic.APIConnectionError` → `ExtractionError`
+
+### Paso 4: Tests unitarios de error handling (TDD)
+**Archivos**: `tests/unit/test_fetchers.py` (nuevo), `tests/unit/test_scraper.py` (ampliar)
+- [ ] Tests para ScrapingBeeFetcher: timeout → FetchError, HTTP 500 → FetchError
+- [ ] Tests para JinaFetcher: idem
+- [ ] Tests para _extract_fields: errores Anthropic → ExtractionError
+- [ ] Ejecutar y verificar que pasan
+
+### Paso 5: SSE event types + scrape_piso_stream
+**Archivo nuevo**: `presentation/schemas/sse_events.py`
+- Definir `ProgressEvent`, `DoneEvent`, `ErrorEvent` (Pydantic models)
+
+**Archivo**: `infrastructure/scraping/llm_scraper.py`
+- [ ] Nuevo método `scrape_piso_stream(url)` → `AsyncGenerator[SseEvent, None]`
+- [ ] Yield secuencia: progress(fetching) → progress(extracting) → progress(saving) → done(piso)
+- [ ] En cada paso, capturar errores y yield ErrorEvent en vez de raise
+- [ ] Mantener `scrape_piso()` original (lo usa en tests existentes), refactorizar para que consuma `scrape_piso_stream` internamente
+
+### Paso 6: Endpoint SSE
+**Archivo**: `presentation/api/pisos.py`
+- [ ] Cambiar `POST /from-url` para devolver `StreamingResponse(media_type="text/event-stream")`
+- [ ] El generador itera `scraper.scrape_piso_stream(url)`, serializa cada evento como `data: {json}\n\n`
+- [ ] El paso "saving" (`service.create_piso`) se ejecuta dentro del generador al recibir `DoneEvent`
+- [ ] Quitar `response_model=PisoOut` y `status_code=201` (ya no aplican a streaming)
+
+### Paso 7: Tests backend SSE
+**Archivo**: `tests/unit/test_scraper.py` (ampliar)
+- [ ] `test_scrape_piso_stream_emits_progress_and_done`
+- [ ] `test_scrape_piso_stream_emits_error_on_fetch_failure`
+- [ ] `test_scrape_piso_stream_emits_error_on_extraction_failure`
+
+### Paso 8: Frontend - utilidad SSE
+**Archivo nuevo**: `frontend/mariland/src/api/sse.ts`
+- [ ] `fetchSSE(url, body, onEvent, signal?)` — usa `fetch` + `ReadableStream` + `TextDecoder` para parsear líneas SSE desde un POST
+
+**Archivo**: `frontend/mariland/src/api/pisos.ts`
+- [ ] Reemplazar `importFromUrl` por `importFromUrlStream(url, onEvent)` que usa `fetchSSE`
+
+**Archivo**: `frontend/mariland/src/types/piso.ts`
+- [ ] Añadir tipos `SseProgressEvent`, `SseDoneEvent`, `SseErrorEvent`, `SseEvent`
+
+### Paso 9: Frontend - UI de progreso
+**Archivo**: `frontend/mariland/src/components/ImportFromUrlModal.tsx`
+- [ ] Reemplazar estado `loading: boolean` por `currentStep` + `errorMessage`
+- [ ] UI: lista de 3 pasos (Obteniendo página / Analizando con IA / Guardando) con estados: pending (gris), active (spinner), done (check verde), error (rojo + mensaje)
+- [ ] Usar `AbortController` para cancelar si el usuario cierra el modal
+- [ ] En error, mostrar mensaje descriptivo del backend (ej: "El portal puede estar bloqueando el acceso automático")
+
+### Paso 10: Tests frontend
+**Archivo nuevo**: `frontend/mariland/src/test/ImportFromUrlModal.test.tsx`
+- [ ] Test: submit muestra pasos de progreso
+- [ ] Test: error event muestra mensaje en el paso correcto
+- [ ] Test: done event llama `onImported` y `onClose`
+
+## Consideraciones
+- **DB session lifetime**: La sesión debe mantenerse viva durante todo el streaming. FastAPI maneja esto correctamente con el dependency injection lifecycle.
+- **Gateway proxy**: El gateway monta sub-apps directamente (no nginx buffer), SSE debería funcionar sin cambios.
+- **CORS**: No requiere cambios, sigue siendo una respuesta HTTP normal.
+- **AbortController**: Si el usuario cierra el modal mid-import, abortar la fetch para no consumir créditos de ScrapingBee innecesariamente (aunque ScrapingBee ya habrá cobrado si la request salió).
+
+## Verificación
+1. `make test APP=mariland` — todos los tests pasan
+2. `make lint APP=mariland` — sin errores
+3. Test manual: importar URL de Fotocasa → ver progreso paso a paso → piso creado
+4. Test manual: importar URL de Idealista (que sabemos que falla) → ver error claro en paso "fetching" con mensaje descriptivo

--- a/backend/mariland/src/mariland/domain/exceptions.py
+++ b/backend/mariland/src/mariland/domain/exceptions.py
@@ -15,3 +15,11 @@ class ValidationError(DomainError):
 
 class ScrapingError(DomainError):
     pass
+
+
+class FetchError(ScrapingError):
+    pass
+
+
+class ExtractionError(ScrapingError):
+    pass

--- a/backend/mariland/src/mariland/infrastructure/scraping/jina_fetcher.py
+++ b/backend/mariland/src/mariland/infrastructure/scraping/jina_fetcher.py
@@ -2,6 +2,8 @@ import logging
 
 import httpx
 
+from mariland.domain.exceptions import FetchError
+
 logger = logging.getLogger(__name__)
 
 
@@ -19,9 +21,26 @@ class JinaFetcher:
             headers["Authorization"] = f"Bearer {self._api_key}"
 
         logger.info("[fetcher:jina] Fetching: %s", jina_url)
-        async with httpx.AsyncClient(timeout=60.0) as client:
-            response = await client.get(jina_url, headers=headers)
-            response.raise_for_status()
+        try:
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                response = await client.get(jina_url, headers=headers)
+                response.raise_for_status()
+        except httpx.TimeoutException as exc:
+            logger.error("[fetcher:jina] Timeout fetching %s: %s", url, exc)
+            raise FetchError(
+                f"Timeout al obtener la página ({url}). El portal tardó demasiado en responder."
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            logger.error(
+                "[fetcher:jina] HTTP %d fetching %s: %s", exc.response.status_code, url, exc
+            )
+            raise FetchError(
+                f"Error HTTP {exc.response.status_code} al obtener la página ({url}). "
+                "El portal puede estar bloqueando el acceso automático."
+            ) from exc
+        except httpx.HTTPError as exc:
+            logger.error("[fetcher:jina] HTTP error fetching %s: %s", url, exc)
+            raise FetchError(f"Error de red al obtener la página ({url}): {exc}") from exc
 
         content = response.text
         logger.info(

--- a/backend/mariland/src/mariland/infrastructure/scraping/llm_scraper.py
+++ b/backend/mariland/src/mariland/infrastructure/scraping/llm_scraper.py
@@ -1,12 +1,15 @@
 import json
 import logging
+from collections.abc import AsyncGenerator
 from typing import Any
 
+import anthropic
 from anthropic import AsyncAnthropic
 from anthropic.types import ToolParam
 
-from mariland.domain.exceptions import ScrapingError
+from mariland.domain.exceptions import ExtractionError, ScrapingError
 from mariland.domain.ports.fetcher import UrlFetcherPort
+from mariland.presentation.schemas.sse_events import DoneEvent, ErrorEvent, ProgressEvent, SseEvent
 
 logger = logging.getLogger(__name__)
 
@@ -94,17 +97,68 @@ class LlmScraper:
         logger.info("[scraper] Scrape complete. Extracted fields: %s", list(non_null.keys()))
         return result
 
+    async def scrape_piso_stream(self, url: str) -> AsyncGenerator[SseEvent, None]:
+        logger.info("[scraper] Starting stream scrape for URL: %s", url)
+
+        yield ProgressEvent(step="fetching", message="Obteniendo página del portal...")
+        try:
+            content = await self._fetcher.fetch_content(url)
+        except ScrapingError as exc:
+            yield ErrorEvent(step="fetching", message=str(exc))
+            return
+
+        logger.info("[scraper] Fetcher returned %d chars", len(content))
+        if len(content) < MIN_CONTENT_CHARS:
+            logger.warning(
+                "[scraper] Insufficient content (%d chars < %d). Possible bot block or empty page.",
+                len(content),
+                MIN_CONTENT_CHARS,
+            )
+            yield ErrorEvent(
+                step="fetching",
+                message=(
+                    f"No se ha podido obtener información de la página ({len(content)} chars). "
+                    "El portal puede estar bloqueando el acceso automático."
+                ),
+            )
+            return
+
+        yield ProgressEvent(step="extracting", message="Analizando datos con IA...")
+        try:
+            extracted = await self._extract_fields(content)
+        except ScrapingError as exc:
+            yield ErrorEvent(step="extracting", message=str(exc))
+            return
+
+        result = {"url": url, "estado": "candidato", **extracted}
+        non_null = {k: v for k, v in result.items() if v is not None}
+        logger.info("[scraper] Extraction complete. Fields: %s", list(non_null.keys()))
+        yield DoneEvent(piso=result)
+
     async def _extract_fields(self, content: str) -> dict[str, Any]:
         input_text = content[:8000]
         logger.info("[scraper] Sending %d chars to Claude Haiku for extraction", len(input_text))
-        response = await self._anthropic.messages.create(
-            model="claude-haiku-4-5",
-            max_tokens=1024,
-            system=SYSTEM_PROMPT,
-            messages=[{"role": "user", "content": input_text}],
-            tools=[EXTRACT_TOOL],
-            tool_choice={"type": "any"},
-        )
+        try:
+            response = await self._anthropic.messages.create(
+                model="claude-haiku-4-5",
+                max_tokens=1024,
+                system=SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": input_text}],
+                tools=[EXTRACT_TOOL],
+                tool_choice={"type": "any"},
+            )
+        except anthropic.APITimeoutError as exc:
+            logger.error("[scraper] Claude API timeout: %s", exc)
+            raise ExtractionError("Timeout al conectar con la IA para extraer datos.") from exc
+        except anthropic.APIStatusError as exc:
+            logger.error("[scraper] Claude API status error %d: %s", exc.status_code, exc)
+            raise ExtractionError(
+                f"Error de la API de IA (HTTP {exc.status_code}) al extraer datos."
+            ) from exc
+        except anthropic.APIConnectionError as exc:
+            logger.error("[scraper] Claude API connection error: %s", exc)
+            raise ExtractionError("Error de conexión con la IA al extraer datos.") from exc
+
         logger.info(
             "[scraper] Claude response: stop_reason=%s, %d content blocks",
             response.stop_reason,

--- a/backend/mariland/src/mariland/infrastructure/scraping/scrapingbee_fetcher.py
+++ b/backend/mariland/src/mariland/infrastructure/scraping/scrapingbee_fetcher.py
@@ -3,6 +3,8 @@ import re
 
 import httpx
 
+from mariland.domain.exceptions import FetchError
+
 logger = logging.getLogger(__name__)
 
 
@@ -32,9 +34,29 @@ class ScrapingBeeFetcher:
         }
 
         logger.info("[fetcher:scrapingbee] Fetching: %s", url)
-        async with httpx.AsyncClient(timeout=60.0) as client:
-            response = await client.get(self._BASE_URL, params=params)
-            response.raise_for_status()
+        try:
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                response = await client.get(self._BASE_URL, params=params)
+                response.raise_for_status()
+        except httpx.TimeoutException as exc:
+            logger.error("[fetcher:scrapingbee] Timeout fetching %s: %s", url, exc)
+            raise FetchError(
+                f"Timeout al obtener la página ({url}). El portal tardó demasiado en responder."
+            ) from exc
+        except httpx.HTTPStatusError as exc:
+            logger.error(
+                "[fetcher:scrapingbee] HTTP %d fetching %s: %s",
+                exc.response.status_code,
+                url,
+                exc,
+            )
+            raise FetchError(
+                f"Error HTTP {exc.response.status_code} al obtener la página ({url}). "
+                "El portal puede estar bloqueando el acceso automático."
+            ) from exc
+        except httpx.HTTPError as exc:
+            logger.error("[fetcher:scrapingbee] HTTP error fetching %s: %s", url, exc)
+            raise FetchError(f"Error de red al obtener la página ({url}): {exc}") from exc
 
         content = _html_to_text(response.text)
         logger.info(

--- a/backend/mariland/src/mariland/presentation/api/pisos.py
+++ b/backend/mariland/src/mariland/presentation/api/pisos.py
@@ -1,4 +1,7 @@
+from collections.abc import AsyncGenerator
+
 from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
 
 from mariland.presentation.dependencies import PisoServiceDep, ScraperDep
 from mariland.presentation.schemas.piso_schemas import (
@@ -7,17 +10,32 @@ from mariland.presentation.schemas.piso_schemas import (
     PisoOut,
     PisoUpdate,
 )
+from mariland.presentation.schemas.sse_events import DoneEvent, ErrorEvent, ProgressEvent
 
 router = APIRouter(prefix="/pisos", tags=["pisos"])
 
 
-@router.post("/from-url", response_model=PisoOut, status_code=201)
+@router.post("/from-url")
 async def create_piso_from_url(
     data: PisoFromUrlRequest, scraper: ScraperDep, service: PisoServiceDep
-) -> PisoOut:
-    piso_data = await scraper.scrape_piso(data.url)
-    piso = await service.create_piso(piso_data)
-    return PisoOut.model_validate(piso)
+) -> StreamingResponse:
+    async def event_stream() -> AsyncGenerator[str, None]:
+        async for event in scraper.scrape_piso_stream(data.url):
+            if isinstance(event, DoneEvent):
+                try:
+                    saving = ProgressEvent(step="saving", message="Guardando piso...")
+                    yield f"data: {saving.model_dump_json()}\n\n"
+                    piso = await service.create_piso(event.piso)
+                    piso_out = PisoOut.model_validate(piso)
+                    done = DoneEvent(piso=piso_out.model_dump(mode="json"))
+                    yield f"data: {done.model_dump_json()}\n\n"
+                except Exception as exc:
+                    error = ErrorEvent(step="saving", message=str(exc))
+                    yield f"data: {error.model_dump_json()}\n\n"
+            else:
+                yield f"data: {event.model_dump_json()}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
 
 
 @router.get("/", response_model=list[PisoOut])

--- a/backend/mariland/src/mariland/presentation/schemas/sse_events.py
+++ b/backend/mariland/src/mariland/presentation/schemas/sse_events.py
@@ -1,0 +1,23 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class ProgressEvent(BaseModel):
+    type: Literal["progress"] = "progress"
+    step: str
+    message: str
+
+
+class DoneEvent(BaseModel):
+    type: Literal["done"] = "done"
+    piso: dict[str, Any]
+
+
+class ErrorEvent(BaseModel):
+    type: Literal["error"] = "error"
+    step: str
+    message: str
+
+
+SseEvent = ProgressEvent | DoneEvent | ErrorEvent

--- a/backend/mariland/tests/unit/test_fetchers.py
+++ b/backend/mariland/tests/unit/test_fetchers.py
@@ -1,0 +1,94 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from mariland.domain.exceptions import FetchError
+from mariland.infrastructure.scraping.jina_fetcher import JinaFetcher
+from mariland.infrastructure.scraping.scrapingbee_fetcher import ScrapingBeeFetcher
+
+# --- ScrapingBeeFetcher ---
+
+
+@pytest.mark.asyncio
+async def test_scrapingbee_fetcher_timeout_raises_fetch_error() -> None:
+    fetcher = ScrapingBeeFetcher(api_key="test-key")
+    with (
+        patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=httpx.ReadTimeout("timeout"))),
+        pytest.raises(FetchError, match="Timeout"),
+    ):
+        await fetcher.fetch_content("https://idealista.com/inmueble/1")
+
+
+@pytest.mark.asyncio
+async def test_scrapingbee_fetcher_http_status_error_raises_fetch_error() -> None:
+    fetcher = ScrapingBeeFetcher(api_key="test-key")
+    mock_response = MagicMock()
+    mock_response.status_code = 500
+    exc = httpx.HTTPStatusError("500", request=MagicMock(), response=mock_response)
+    with (
+        patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=exc)),
+        pytest.raises(FetchError, match="Error HTTP 500"),
+    ):
+        await fetcher.fetch_content("https://idealista.com/inmueble/1")
+
+
+@pytest.mark.asyncio
+async def test_scrapingbee_fetcher_http_error_raises_fetch_error() -> None:
+    fetcher = ScrapingBeeFetcher(api_key="test-key")
+    with (
+        patch(
+            "httpx.AsyncClient.get", new=AsyncMock(side_effect=httpx.ConnectError("conn error"))
+        ),
+        pytest.raises(FetchError, match="Error de red"),
+    ):
+        await fetcher.fetch_content("https://idealista.com/inmueble/1")
+
+
+@pytest.mark.asyncio
+async def test_scrapingbee_fetcher_returns_text_on_success() -> None:
+    fetcher = ScrapingBeeFetcher(api_key="test-key")
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = "<html><body>Piso en venta</body></html>"
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=mock_response)):
+        result = await fetcher.fetch_content("https://idealista.com/inmueble/1")
+    assert "Piso en venta" in result
+
+
+# --- JinaFetcher ---
+
+
+@pytest.mark.asyncio
+async def test_jina_fetcher_timeout_raises_fetch_error() -> None:
+    fetcher = JinaFetcher()
+    with (
+        patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=httpx.ReadTimeout("timeout"))),
+        pytest.raises(FetchError, match="Timeout"),
+    ):
+        await fetcher.fetch_content("https://fotocasa.es/piso/1")
+
+
+@pytest.mark.asyncio
+async def test_jina_fetcher_http_status_error_raises_fetch_error() -> None:
+    fetcher = JinaFetcher()
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    exc = httpx.HTTPStatusError("403", request=MagicMock(), response=mock_response)
+    with (
+        patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=exc)),
+        pytest.raises(FetchError, match="Error HTTP 403"),
+    ):
+        await fetcher.fetch_content("https://fotocasa.es/piso/1")
+
+
+@pytest.mark.asyncio
+async def test_jina_fetcher_http_error_raises_fetch_error() -> None:
+    fetcher = JinaFetcher()
+    with (
+        patch(
+            "httpx.AsyncClient.get", new=AsyncMock(side_effect=httpx.ConnectError("conn error"))
+        ),
+        pytest.raises(FetchError, match="Error de red"),
+    ):
+        await fetcher.fetch_content("https://fotocasa.es/piso/1")

--- a/backend/mariland/tests/unit/test_scraper.py
+++ b/backend/mariland/tests/unit/test_scraper.py
@@ -1,10 +1,12 @@
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import anthropic
 import pytest
 
-from mariland.domain.exceptions import ScrapingError
+from mariland.domain.exceptions import ExtractionError, FetchError, ScrapingError
 from mariland.infrastructure.scraping.llm_scraper import LlmScraper
+from mariland.presentation.schemas.sse_events import DoneEvent, ErrorEvent, ProgressEvent
 
 
 def make_tool_use_block(input_data: dict[str, Any]) -> MagicMock:
@@ -97,3 +99,119 @@ async def test_extract_fields_returns_empty_dict_when_no_tool_use(scraper: LlmSc
     result = await scraper._extract_fields("some content")
 
     assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_extract_fields_raises_extraction_error_on_api_timeout(
+    scraper: LlmScraper,
+) -> None:
+    mock_anthropic = AsyncMock()
+    mock_anthropic.messages.create = AsyncMock(
+        side_effect=anthropic.APITimeoutError(request=MagicMock())
+    )
+    scraper._anthropic = mock_anthropic
+
+    with pytest.raises(ExtractionError, match="Timeout"):
+        await scraper._extract_fields("some content")
+
+
+@pytest.mark.asyncio
+async def test_extract_fields_raises_extraction_error_on_api_status_error(
+    scraper: LlmScraper,
+) -> None:
+    mock_anthropic = AsyncMock()
+    mock_response = MagicMock()
+    mock_response.status_code = 429
+    mock_anthropic.messages.create = AsyncMock(
+        side_effect=anthropic.APIStatusError("rate limit", response=mock_response, body=None)
+    )
+    scraper._anthropic = mock_anthropic
+
+    with pytest.raises(ExtractionError, match="429"):
+        await scraper._extract_fields("some content")
+
+
+@pytest.mark.asyncio
+async def test_extract_fields_raises_extraction_error_on_connection_error(
+    scraper: LlmScraper,
+) -> None:
+    mock_anthropic = AsyncMock()
+    mock_anthropic.messages.create = AsyncMock(
+        side_effect=anthropic.APIConnectionError(request=MagicMock())
+    )
+    scraper._anthropic = mock_anthropic
+
+    with pytest.raises(ExtractionError, match="conexión"):
+        await scraper._extract_fields("some content")
+
+
+# --- scrape_piso_stream ---
+
+
+async def collect_events(scraper: LlmScraper, url: str) -> list:
+    return [event async for event in scraper.scrape_piso_stream(url)]
+
+
+@pytest.mark.asyncio
+async def test_scrape_piso_stream_emits_progress_and_done(
+    scraper: LlmScraper, mock_fetcher: AsyncMock
+) -> None:
+    mock_fetcher.fetch_content.return_value = "x" * 3000
+    extracted = {"direccion": "Calle Mayor 1", "precio": 200000}
+    with patch.object(scraper, "_extract_fields", new=AsyncMock(return_value=extracted)):
+        events = await collect_events(scraper, "https://fotocasa.es/piso/1")
+
+    progress_steps = [e.step for e in events if isinstance(e, ProgressEvent)]
+    assert progress_steps == ["fetching", "extracting"]
+    assert isinstance(events[-1], DoneEvent)
+    assert events[-1].piso["url"] == "https://fotocasa.es/piso/1"
+    assert events[-1].piso["estado"] == "candidato"
+    assert events[-1].piso["precio"] == 200000
+
+
+@pytest.mark.asyncio
+async def test_scrape_piso_stream_emits_error_on_fetch_failure(
+    scraper: LlmScraper, mock_fetcher: AsyncMock
+) -> None:
+    mock_fetcher.fetch_content.side_effect = FetchError("Timeout al obtener la página")
+    events = await collect_events(scraper, "https://idealista.com/inmueble/1")
+
+    assert len(events) == 2
+    assert isinstance(events[0], ProgressEvent)
+    assert events[0].step == "fetching"
+    assert isinstance(events[1], ErrorEvent)
+    assert events[1].step == "fetching"
+    assert "Timeout" in events[1].message
+
+
+@pytest.mark.asyncio
+async def test_scrape_piso_stream_emits_error_on_insufficient_content(
+    scraper: LlmScraper, mock_fetcher: AsyncMock
+) -> None:
+    mock_fetcher.fetch_content.return_value = "too short"
+    events = await collect_events(scraper, "https://idealista.com/inmueble/1")
+
+    error_events = [e for e in events if isinstance(e, ErrorEvent)]
+    assert len(error_events) == 1
+    assert error_events[0].step == "fetching"
+
+
+@pytest.mark.asyncio
+async def test_scrape_piso_stream_emits_error_on_extraction_failure(
+    scraper: LlmScraper, mock_fetcher: AsyncMock
+) -> None:
+    mock_fetcher.fetch_content.return_value = "x" * 3000
+    with patch.object(
+        scraper,
+        "_extract_fields",
+        new=AsyncMock(side_effect=ExtractionError("Error de IA")),
+    ):
+        events = await collect_events(scraper, "https://fotocasa.es/piso/1")
+
+    progress_steps = [e.step for e in events if isinstance(e, ProgressEvent)]
+    assert "fetching" in progress_steps
+    assert "extracting" in progress_steps
+    error_events = [e for e in events if isinstance(e, ErrorEvent)]
+    assert len(error_events) == 1
+    assert error_events[0].step == "extracting"
+    assert "IA" in error_events[0].message

--- a/frontend/mariland/src/api/pisos.ts
+++ b/frontend/mariland/src/api/pisos.ts
@@ -1,11 +1,15 @@
-import type { Comment, CommentCreate, Piso, PisoCreate, PisoUpdate, PriceHistory, PriceHistoryCreate } from '../types/piso'
+import type { Comment, CommentCreate, Piso, PisoCreate, PisoUpdate, PriceHistory, PriceHistoryCreate, SseEvent } from '../types/piso'
 import { apiClient } from './client'
+import { fetchSSE } from './sse'
+
+const BASE = (import.meta.env.VITE_MARILAND_API_BASE_URL ?? '') + '/api'
 
 export const pisosApi = {
   list: () => apiClient.get<Piso[]>('/pisos/'),
   get: (id: number) => apiClient.get<Piso>(`/pisos/${id}`),
   create: (data: PisoCreate) => apiClient.post<Piso>('/pisos/', data),
-  importFromUrl: (url: string) => apiClient.post<Piso>('/pisos/from-url', { url }),
+  importFromUrlStream: (url: string, onEvent: (event: SseEvent) => void, signal?: AbortSignal) =>
+    fetchSSE(`${BASE}/pisos/from-url`, { url }, (data) => onEvent(data as SseEvent), signal),
   update: (id: number, data: PisoUpdate) => apiClient.put<Piso>(`/pisos/${id}`, data),
   delete: (id: number) => apiClient.delete<void>(`/pisos/${id}`),
 }

--- a/frontend/mariland/src/api/sse.ts
+++ b/frontend/mariland/src/api/sse.ts
@@ -1,0 +1,48 @@
+export async function fetchSSE(
+  url: string,
+  body: unknown,
+  onEvent: (data: unknown) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`${res.status}: ${text}`)
+  }
+
+  const reader = res.body?.getReader()
+  if (!reader) return
+
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n\n')
+      buffer = lines.pop() ?? ''
+
+      for (const chunk of lines) {
+        const dataLine = chunk.trim()
+        if (dataLine.startsWith('data: ')) {
+          try {
+            onEvent(JSON.parse(dataLine.slice(6)))
+          } catch {
+            // ignore malformed lines
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}

--- a/frontend/mariland/src/components/ImportFromUrlModal.tsx
+++ b/frontend/mariland/src/components/ImportFromUrlModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { pisosApi } from '../api/pisos'
 import type { Piso } from '../types/piso'
 import Modal from './Modal'
@@ -8,41 +8,108 @@ interface ImportFromUrlModalProps {
   onClose: () => void
 }
 
+type Step = 'fetching' | 'extracting' | 'saving'
+
+const STEPS: { id: Step; label: string }[] = [
+  { id: 'fetching', label: 'Obteniendo página del portal' },
+  { id: 'extracting', label: 'Analizando datos con IA' },
+  { id: 'saving', label: 'Guardando piso' },
+]
+
+type StepState = 'pending' | 'active' | 'done' | 'error'
+
+function getStepState(
+  stepId: Step,
+  currentStep: Step | null,
+  errorStep: Step | null,
+  isDone: boolean,
+): StepState {
+  const order: Step[] = ['fetching', 'extracting', 'saving']
+  const stepIdx = order.indexOf(stepId)
+  const currentIdx = currentStep ? order.indexOf(currentStep) : -1
+
+  if (errorStep === stepId) return 'error'
+  if (isDone || stepIdx < currentIdx) return 'done'
+  if (stepId === currentStep) return 'active'
+  return 'pending'
+}
+
+function StepIcon({ state }: { state: StepState }) {
+  if (state === 'active') {
+    return (
+      <svg className="h-5 w-5 animate-spin text-blue-600" viewBox="0 0 24 24" fill="none">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+      </svg>
+    )
+  }
+  if (state === 'done') {
+    return (
+      <svg className="h-5 w-5 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+      </svg>
+    )
+  }
+  if (state === 'error') {
+    return (
+      <svg className="h-5 w-5 text-red-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+      </svg>
+    )
+  }
+  return <div className="h-5 w-5 rounded-full border-2 border-gray-300" />
+}
+
 export default function ImportFromUrlModal({ onImported, onClose }: ImportFromUrlModalProps) {
   const [url, setUrl] = useState('')
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [currentStep, setCurrentStep] = useState<Step | null>(null)
+  const [errorStep, setErrorStep] = useState<Step | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const handleClose = () => {
+    abortRef.current?.abort()
+    onClose()
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!url.trim()) return
-    setLoading(true)
-    setError(null)
+
+    setCurrentStep(null)
+    setErrorStep(null)
+    setErrorMessage(null)
+
+    const controller = new AbortController()
+    abortRef.current = controller
+
     try {
-      const piso = await pisosApi.importFromUrl(url.trim())
-      if (piso) {
-        onImported(piso)
-        onClose()
-      }
+      await pisosApi.importFromUrlStream(
+        url.trim(),
+        (event) => {
+          if (event.type === 'progress') {
+            setCurrentStep(event.step as Step)
+          } else if (event.type === 'error') {
+            setErrorStep(event.step as Step)
+            setErrorMessage(event.message)
+          } else if (event.type === 'done') {
+            onImported(event.piso)
+            onClose()
+          }
+        },
+        controller.signal,
+      )
     } catch (e) {
-      let message = 'No se ha podido importar el piso. Comprueba el enlace e inténtalo de nuevo.'
-      if (e instanceof Error) {
-        const match = e.message.match(/^\d+: (.+)$/)
-        if (match) {
-          try {
-            const body = JSON.parse(match[1]) as { detail?: string }
-            if (body.detail) message = body.detail
-          } catch { /* use default message */ }
-        }
-      }
-      setError(message)
-    } finally {
-      setLoading(false)
+      if (e instanceof Error && e.name === 'AbortError') return
+      setErrorStep(currentStep ?? 'fetching')
+      setErrorMessage('Error de conexión. Inténtalo de nuevo.')
     }
   }
 
+  const showProgress = currentStep !== null
+
   return (
-    <Modal title="Importar piso desde URL" onClose={onClose} size="md">
+    <Modal title="Importar piso desde URL" onClose={handleClose} size="md">
       <form onSubmit={handleSubmit} className="space-y-4">
         <p className="text-sm text-gray-500">
           Pega el enlace del piso de Fotocasa, Idealista u otro portal y lo importaremos automáticamente.
@@ -54,32 +121,69 @@ export default function ImportFromUrlModal({ onImported, onClose }: ImportFromUr
             value={url}
             onChange={(e) => setUrl(e.target.value)}
             placeholder="https://www.fotocasa.es/..."
-            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-gray-50"
             required
             autoFocus
+            disabled={showProgress}
           />
         </div>
-        {error && <p className="text-sm text-red-600">{error}</p>}
+
+        {showProgress && (
+          <ul className="space-y-2 rounded-lg border border-gray-100 bg-gray-50 px-4 py-3">
+            {STEPS.map((step) => {
+              const state = getStepState(step.id, currentStep, errorStep, false)
+              return (
+                <li key={step.id} className="flex items-center gap-3">
+                  <StepIcon state={state} />
+                  <span
+                    className={
+                      state === 'error'
+                        ? 'text-sm font-medium text-red-600'
+                        : state === 'done'
+                          ? 'text-sm text-gray-400 line-through'
+                          : state === 'active'
+                            ? 'text-sm font-medium text-gray-900'
+                            : 'text-sm text-gray-400'
+                    }
+                  >
+                    {step.label}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+
+        {errorMessage && (
+          <p className="text-sm text-red-600">{errorMessage}</p>
+        )}
+
         <div className="flex justify-end gap-2 pt-2">
           <button
             type="button"
-            onClick={onClose}
+            onClick={handleClose}
             className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
           >
             Cancelar
           </button>
           <button
             type="submit"
-            disabled={loading || !url.trim()}
+            disabled={showProgress && !errorStep || !url.trim()}
             className="flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
           >
-            {loading && (
-              <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
-              </svg>
+            {showProgress && !errorStep ? (
+              <>
+                <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+                </svg>
+                Importando...
+              </>
+            ) : errorStep ? (
+              'Reintentar'
+            ) : (
+              'Importar'
             )}
-            {loading ? 'Importando...' : 'Importar'}
           </button>
         </div>
       </form>

--- a/frontend/mariland/src/test/ImportFromUrlModal.test.tsx
+++ b/frontend/mariland/src/test/ImportFromUrlModal.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ImportFromUrlModal from '../components/ImportFromUrlModal'
+import * as pisosApiModule from '../api/pisos'
+import type { Piso, SseEvent } from '../types/piso'
+
+const basePiso: Piso = {
+  id: 1,
+  url: 'https://fotocasa.es/piso/1',
+  imagen_url: null,
+  direccion: 'Calle Mayor 1',
+  barrio: 'Centre',
+  precio: 250000,
+  habitaciones: 3,
+  banos: 1,
+  metros: 80,
+  planta: null,
+  ascensor: null,
+  parking: null,
+  certificacion_energetica: null,
+  orientacion: null,
+  contacto_nombre: null,
+  contacto_telefono: null,
+  contacto_inmobiliaria: null,
+  estado: 'candidato',
+  extras: null,
+  notas: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  price_history: [],
+  comments: [],
+}
+
+function mockImportStream(events: SseEvent[]) {
+  return vi.spyOn(pisosApiModule.pisosApi, 'importFromUrlStream').mockImplementation(
+    async (_url, onEvent) => {
+      for (const event of events) {
+        onEvent(event)
+      }
+    },
+  )
+}
+
+describe('ImportFromUrlModal', () => {
+  const onImported = vi.fn()
+  const onClose = vi.fn()
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    onImported.mockClear()
+    onClose.mockClear()
+  })
+
+  it('renders form with url input and submit button', () => {
+    render(<ImportFromUrlModal onImported={onImported} onClose={onClose} />)
+    expect(screen.getByPlaceholderText(/fotocasa/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /importar/i })).toBeInTheDocument()
+  })
+
+  it('shows progress steps while importing', async () => {
+    const user = userEvent.setup()
+    mockImportStream([
+      { type: 'progress', step: 'fetching', message: 'Obteniendo página...' },
+      { type: 'progress', step: 'extracting', message: 'Analizando...' },
+      { type: 'progress', step: 'saving', message: 'Guardando...' },
+      { type: 'done', piso: basePiso },
+    ])
+
+    render(<ImportFromUrlModal onImported={onImported} onClose={onClose} />)
+    await user.type(screen.getByPlaceholderText(/fotocasa/i), 'https://fotocasa.es/piso/1')
+    await user.click(screen.getByRole('button', { name: /importar/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Obteniendo página del portal')).toBeInTheDocument()
+      expect(screen.getByText('Analizando datos con IA')).toBeInTheDocument()
+      expect(screen.getByText('Guardando piso')).toBeInTheDocument()
+    })
+  })
+
+  it('calls onImported and onClose on done event', async () => {
+    const user = userEvent.setup()
+    mockImportStream([
+      { type: 'progress', step: 'fetching', message: 'Obteniendo...' },
+      { type: 'done', piso: basePiso },
+    ])
+
+    render(<ImportFromUrlModal onImported={onImported} onClose={onClose} />)
+    await user.type(screen.getByPlaceholderText(/fotocasa/i), 'https://fotocasa.es/piso/1')
+    await user.click(screen.getByRole('button', { name: /importar/i }))
+
+    await waitFor(() => {
+      expect(onImported).toHaveBeenCalledWith(basePiso)
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+
+  it('shows error message at failed step on error event', async () => {
+    const user = userEvent.setup()
+    mockImportStream([
+      { type: 'progress', step: 'fetching', message: 'Obteniendo...' },
+      {
+        type: 'error',
+        step: 'fetching',
+        message: 'El portal puede estar bloqueando el acceso automático.',
+      },
+    ])
+
+    render(<ImportFromUrlModal onImported={onImported} onClose={onClose} />)
+    await user.type(screen.getByPlaceholderText(/fotocasa/i), 'https://idealista.com/inmueble/1')
+    await user.click(screen.getByRole('button', { name: /importar/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('El portal puede estar bloqueando el acceso automático.'),
+      ).toBeInTheDocument()
+    })
+    expect(onImported).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /reintentar/i })).toBeInTheDocument()
+  })
+
+  it('does not call onImported on error', async () => {
+    const user = userEvent.setup()
+    mockImportStream([
+      { type: 'error', step: 'fetching', message: 'Timeout' },
+    ])
+
+    render(<ImportFromUrlModal onImported={onImported} onClose={onClose} />)
+    await user.type(screen.getByPlaceholderText(/fotocasa/i), 'https://idealista.com/inmueble/1')
+    await user.click(screen.getByRole('button', { name: /importar/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Timeout')).toBeInTheDocument()
+    })
+    expect(onImported).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/mariland/src/types/piso.ts
+++ b/frontend/mariland/src/types/piso.ts
@@ -64,6 +64,11 @@ export interface PisoCreate {
 
 export type PisoUpdate = PisoCreate
 
+export type SseProgressEvent = { type: 'progress'; step: string; message: string }
+export type SseDoneEvent = { type: 'done'; piso: Piso }
+export type SseErrorEvent = { type: 'error'; step: string; message: string }
+export type SseEvent = SseProgressEvent | SseDoneEvent | SseErrorEvent
+
 export interface PriceHistoryCreate {
   precio: number
   notas?: string | null


### PR DESCRIPTION
## Summary

- Add granular domain exceptions (`FetchError`, `ExtractionError`) for clearer error reporting
- Catch httpx timeouts/HTTP errors in fetchers with descriptive messages (URL + cause, including bot-block hint)
- Increase ScrapingBee timeout from 60s to 120s
- Catch Anthropic API errors in `LlmScraper._extract_fields`
- Change `POST /pisos/from-url` to Server-Sent Events stream so frontend gets real-time step feedback
- Frontend `ImportFromUrlModal` now shows step-by-step progress (fetching → extracting → saving) with pending/active/done/error states
- AbortController cancels the SSE stream if the user closes the modal (ScrapingBee credit already spent, but Claude tokens and DB save are avoided)

## Context

Fixes #9. Root cause: Idealista has bot protection ("checking device...") that ScrapingBee can't bypass → ScrapingBee returns 500 after a long delay → our httpx timeout fires → generic 500 to the user. We can't fix the bot-block, but now the user sees exactly which step failed and why.

## Changes

- `domain/exceptions.py` — `FetchError`, `ExtractionError` subclasses of `ScrapingError`
- `infrastructure/scraping/scrapingbee_fetcher.py` — error handling + timeout 120s
- `infrastructure/scraping/jina_fetcher.py` — error handling
- `infrastructure/scraping/llm_scraper.py` — Anthropic error handling + `scrape_piso_stream()` async generator
- `presentation/api/pisos.py` — SSE `StreamingResponse` endpoint
- `presentation/schemas/sse_events.py` — `ProgressEvent`, `DoneEvent`, `ErrorEvent` Pydantic models
- `frontend/src/api/sse.ts` — `fetchSSE()` utility for POST-based SSE
- `frontend/src/api/pisos.ts` — `importFromUrlStream()`
- `frontend/src/types/piso.ts` — SSE event types
- `frontend/src/components/ImportFromUrlModal.tsx` — progress UI with step states
- New tests: `test_fetchers.py`, extended `test_scraper.py`, `ImportFromUrlModal.test.tsx`

## Testing

- [ ] `make test APP=mariland` → 61 passed
- [ ] `make test-frontend APP=mariland` → 36 passed
- [ ] `make lint APP=mariland` → clean
- [ ] `make lint-frontend APP=mariland` → clean
- [ ] Manual: import a Fotocasa URL → see progress steps → piso created
- [ ] Manual: import an Idealista URL → see error at "fetching" step with message "El portal tardó demasiado o está bloqueando el acceso automático."

🤖 Generated with [Claude Code](https://claude.com/claude-code)