### PR TITLE
feat(mariland): inline estado dropdown on PisoCard (#11)

### DIFF
--- a/.claude/plans/issue-11-inline-estado-dropdown.md
+++ b/.claude/plans/issue-11-inline-estado-dropdown.md
@@ -1,0 +1,49 @@
+# Issue #11: Edicion de estado del piso sin modal
+
+## Context
+
+Actualmente, para cambiar el estado de un piso (candidato, contactado, agendado, etc.) hay que abrir el modal completo de edicion. Como el estado se cambia frecuentemente, esto es tedioso. La mejora consiste en hacer el badge de estado clickable directamente en la PisoCard, mostrando un dropdown para cambiar el estado con un solo click.
+
+## Cambios necesarios
+
+Es un cambio **solo de frontend**. El backend ya soporta actualizar solo el campo `estado` via `PUT /pisos/{piso_id}` con `{ estado: "nuevo_valor" }`.
+
+### Archivos a modificar
+
+1. **`frontend/mariland/src/components/PisoCard.tsx`**
+   - Reemplazar el `<span>` estatico del estado (linea 80-82) por un nuevo componente `EstadoDropdown`
+   - Pasar `piso.id`, `piso.estado` y un callback `onEstadoChange` como props
+
+2. **`frontend/mariland/src/components/EstadoDropdown.tsx`** (nuevo)
+   - Componente que muestra el badge actual del estado (mismos colores de `ESTADO_COLORS`)
+   - Al hacer click, abre un dropdown con todas las opciones de estado
+   - Al seleccionar una opcion, llama al callback `onEstadoChange(id, nuevoEstado)`
+   - Cierra el dropdown al seleccionar o al hacer click fuera (click-outside)
+   - Muestra estado de loading (spinner o opacidad reducida) mientras se guarda
+   - Reutilizar `ESTADO_COLORS` (moverlo o exportarlo)
+
+3. **`frontend/mariland/src/App.tsx`**
+   - Pasar un nuevo callback `onEstadoChange` a cada `PisoCard` que llame a `updatePiso(id, { estado })`
+
+### Detalles de implementacion
+
+- **`ESTADO_COLORS`** y **`ESTADOS`**: Extraer las constantes a un archivo compartido o exportarlas desde `PisoCard.tsx` para reutilizar en el dropdown (actualmente `ESTADOS` esta duplicada en `PisoForm.tsx` y `Filters.tsx`)
+- **Dropdown**: Usar `position: absolute` con `z-index` alto para que no quede cortado por la card. Usar un `useRef` + event listener para cerrar al click fuera
+- **Feedback visual**: El badge actual se marca como "seleccionado" en el dropdown. Mientras se guarda, mostrar opacidad reducida o un spinner pequeno
+- **Accesibilidad**: El dropdown debe poder cerrarse con Escape
+
+## Pasos de implementacion
+
+- [x] 1. Crear constantes compartidas `ESTADOS` y `ESTADO_COLORS` (extraer de PisoCard)
+- [x] 2. Crear tests para el componente `EstadoDropdown`
+- [x] 3. Crear componente `EstadoDropdown`
+- [x] 4. Integrar `EstadoDropdown` en `PisoCard` (reemplazar badge estatico)
+- [x] 5. Pasar callback `onEstadoChange` desde `App.tsx` a `PisoCard`
+- [x] 6. Ejecutar linters y tests
+- [ ] 7. Verificar manualmente en el navegador
+
+## Verificacion
+
+1. `make lint APP=mariland` — linters pasan
+2. `make test APP=mariland` — tests pasan (si hay tests frontend configurados)
+3. Verificacion manual: abrir la app, hacer click en el badge de estado de una card, seleccionar otro estado, verificar que se guarda y la card se actualiza

--- a/frontend/mariland/src/App.tsx
+++ b/frontend/mariland/src/App.tsx
@@ -126,6 +126,7 @@ export default function App() {
               onComments={() => setCommentPiso(piso)}
               onPrices={() => setPricePiso(piso)}
               onExtras={() => setExtrasPiso(piso)}
+              onEstadoChange={(id, estado) => updatePiso(id, { estado })}
             />
           ))}
         </div>

--- a/frontend/mariland/src/components/EstadoDropdown.tsx
+++ b/frontend/mariland/src/components/EstadoDropdown.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef, useState } from 'react'
+import { ESTADO_COLORS, ESTADOS } from '../utils/estadoUtils'
+
+interface EstadoDropdownProps {
+  pisoId: number
+  estado: string
+  onEstadoChange: (id: number, estado: string) => void
+}
+
+export default function EstadoDropdown({ pisoId, estado, onEstadoChange }: EstadoDropdownProps) {
+  const [open, setOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  async function handleSelect(nuevoEstado: string) {
+    if (nuevoEstado === estado) {
+      setOpen(false)
+      return
+    }
+    setOpen(false)
+    setSaving(true)
+    try {
+      await onEstadoChange(pisoId, nuevoEstado)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium transition ${ESTADO_COLORS[estado] ?? 'bg-gray-100 text-gray-600'} ${saving ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:ring-2 hover:ring-offset-1 hover:ring-gray-300'}`}
+        disabled={saving}
+      >
+        {estado}
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 min-w-[130px] rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+          {ESTADOS.map((e) => (
+            <button
+              key={e}
+              type="button"
+              onClick={() => handleSelect(e)}
+              className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-gray-50 ${e === estado ? 'font-semibold' : ''}`}
+            >
+              <span className={`rounded-full px-2 py-0.5 ${ESTADO_COLORS[e] ?? 'bg-gray-100 text-gray-600'}`}>
+                {e}
+              </span>
+              {e === estado && <span className="ml-auto text-gray-400">✓</span>}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/mariland/src/components/Filters.tsx
+++ b/frontend/mariland/src/components/Filters.tsx
@@ -1,4 +1,4 @@
-const ESTADOS = ['candidato', 'contactado', 'agendado', 'visitado', 'descartado', 'oferta', 'comprado']
+import { ESTADOS } from '../utils/estadoUtils'
 
 interface FiltersProps {
   search: string

--- a/frontend/mariland/src/components/PisoCard.tsx
+++ b/frontend/mariland/src/components/PisoCard.tsx
@@ -1,17 +1,8 @@
 import { useState } from 'react'
 import type { Piso, PriceHistory } from '../types/piso'
 import ActionMenu from './ActionMenu'
+import EstadoDropdown from './EstadoDropdown'
 import ImagenModal from './ImagenModal'
-
-const ESTADO_COLORS: Record<string, string> = {
-  candidato: 'bg-blue-100 text-blue-700',
-  contactado: 'bg-orange-100 text-orange-700',
-  agendado: 'bg-teal-100 text-teal-700',
-  visitado: 'bg-purple-100 text-purple-700',
-  descartado: 'bg-gray-100 text-gray-500',
-  oferta: 'bg-yellow-100 text-yellow-700',
-  comprado: 'bg-green-100 text-green-700',
-}
 
 const CERT_COLORS: Record<string, string> = {
   A: 'bg-green-600', B: 'bg-green-400', C: 'bg-yellow-400',
@@ -40,9 +31,10 @@ interface PisoCardProps {
   onComments: () => void
   onPrices: () => void
   onExtras: () => void
+  onEstadoChange: (id: number, estado: string) => void
 }
 
-export default function PisoCard({ piso, onEdit, onDelete, onComments, onPrices, onExtras }: PisoCardProps) {
+export default function PisoCard({ piso, onEdit, onDelete, onComments, onPrices, onExtras, onEstadoChange }: PisoCardProps) {
   const [showImagenModal, setShowImagenModal] = useState(false)
   const variation = priceVariation(piso)
   const precioM2 = piso.precio && piso.metros ? Math.round(piso.precio / piso.metros) : null
@@ -77,9 +69,7 @@ export default function PisoCard({ piso, onEdit, onDelete, onComments, onPrices,
               {piso.certificacion_energetica}
             </span>
           )}
-          <span className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium ${ESTADO_COLORS[piso.estado] ?? 'bg-gray-100 text-gray-600'}`}>
-            {piso.estado}
-          </span>
+          <EstadoDropdown pisoId={piso.id} estado={piso.estado} onEstadoChange={onEstadoChange} />
           <ActionMenu
             onEdit={onEdit}
             onDelete={onDelete}

--- a/frontend/mariland/src/components/PisoForm.tsx
+++ b/frontend/mariland/src/components/PisoForm.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react'
 import type { Piso, PisoCreate, PisoUpdate } from '../types/piso'
+import { ESTADOS } from '../utils/estadoUtils'
 import Modal from './Modal'
-
-const ESTADOS = ['candidato', 'contactado', 'agendado', 'visitado', 'descartado', 'oferta', 'comprado']
 const CERT_ENERGETICA = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'en trámite', 'exento']
 const ORIENTACIONES = ['Norte', 'Noreste', 'Este', 'Sureste', 'Sur', 'Suroeste', 'Oeste', 'Noroeste']
 const BARRIOS = [

--- a/frontend/mariland/src/test/EstadoDropdown.test.tsx
+++ b/frontend/mariland/src/test/EstadoDropdown.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import EstadoDropdown from '../components/EstadoDropdown'
+
+function renderDropdown(estado = 'candidato', onEstadoChange = vi.fn()) {
+  render(<EstadoDropdown pisoId={1} estado={estado} onEstadoChange={onEstadoChange} />)
+  return { onEstadoChange }
+}
+
+describe('EstadoDropdown', () => {
+  it('renders current estado badge', () => {
+    renderDropdown('candidato')
+    expect(screen.getByText('candidato')).toBeInTheDocument()
+  })
+
+  it('opens dropdown when badge is clicked', async () => {
+    const user = userEvent.setup()
+    renderDropdown('candidato')
+    await user.click(screen.getByText('candidato'))
+    expect(screen.getByText('contactado')).toBeInTheDocument()
+    expect(screen.getByText('agendado')).toBeInTheDocument()
+  })
+
+  it('calls onEstadoChange with new estado when option is selected', async () => {
+    const user = userEvent.setup()
+    const { onEstadoChange } = renderDropdown('candidato')
+    await user.click(screen.getByText('candidato'))
+    await user.click(screen.getAllByText('contactado')[0])
+    expect(onEstadoChange).toHaveBeenCalledWith(1, 'contactado')
+  })
+
+  it('closes dropdown after selecting an option', async () => {
+    const user = userEvent.setup()
+    renderDropdown('candidato')
+    await user.click(screen.getByText('candidato'))
+    await user.click(screen.getAllByText('contactado')[0])
+    expect(screen.queryByText('agendado')).not.toBeInTheDocument()
+  })
+
+  it('closes dropdown when pressing Escape', async () => {
+    const user = userEvent.setup()
+    renderDropdown('candidato')
+    await user.click(screen.getByText('candidato'))
+    expect(screen.getByText('agendado')).toBeInTheDocument()
+    await user.keyboard('{Escape}')
+    expect(screen.queryByText('agendado')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/mariland/src/test/PisoCard.test.tsx
+++ b/frontend/mariland/src/test/PisoCard.test.tsx
@@ -39,6 +39,7 @@ function renderCard(overrides: Partial<Piso> = {}) {
     onComments: vi.fn(),
     onPrices: vi.fn(),
     onExtras: vi.fn(),
+    onEstadoChange: vi.fn(),
   }
   render(<PisoCard {...props} />)
   return props

--- a/frontend/mariland/src/utils/estadoUtils.ts
+++ b/frontend/mariland/src/utils/estadoUtils.ts
@@ -1,0 +1,11 @@
+export const ESTADOS = ['candidato', 'contactado', 'agendado', 'visitado', 'descartado', 'oferta', 'comprado']
+
+export const ESTADO_COLORS: Record<string, string> = {
+  candidato: 'bg-blue-100 text-blue-700',
+  contactado: 'bg-orange-100 text-orange-700',
+  agendado: 'bg-teal-100 text-teal-700',
+  visitado: 'bg-purple-100 text-purple-700',
+  descartado: 'bg-gray-100 text-gray-500',
+  oferta: 'bg-yellow-100 text-yellow-700',
+  comprado: 'bg-green-100 text-green-700',
+}


### PR DESCRIPTION
## Summary

- Reemplaza el badge estático de estado en `PisoCard` por un componente `EstadoDropdown` clickable
- Al hacer click en el badge, aparece un dropdown con todos los estados posibles
- Al seleccionar un estado, se guarda automáticamente via `PUT /pisos/{id}` sin abrir el modal completo
- Extrae `ESTADOS` y `ESTADO_COLORS` a `src/utils/estadoUtils.ts` para evitar duplicación

## Context

Cambiar el estado de un piso (candidato → agendado, etc.) es una acción frecuente. Abrir el modal completo solo para este cambio era tedioso. Closes #11.

## Changes

- `src/utils/estadoUtils.ts` — constantes compartidas (nuevo)
- `src/components/EstadoDropdown.tsx` — componente dropdown inline (nuevo)
- `src/components/PisoCard.tsx` — integra `EstadoDropdown`, añade prop `onEstadoChange`
- `src/App.tsx` — pasa `onEstadoChange` a cada `PisoCard`
- `src/components/PisoForm.tsx`, `Filters.tsx` — importan desde `estadoUtils` en lugar de redefinir

## Testing

- 5 nuevos tests en `EstadoDropdown.test.tsx`: render, open/close, selección, Escape
- Tests existentes de `PisoCard` actualizados con la nueva prop

## Test Plan

- [ ] Revisar el Cloudflare Pages preview de esta PR
- [ ] Hacer click en el badge de estado de cualquier piso → debe abrirse el dropdown
- [ ] Seleccionar otro estado → debe cerrarse el dropdown y actualizarse el badge
- [ ] Verificar que el cambio persiste al recargar la página

🤖 Generated with [Claude Code](https://claude.com/claude-code)