### PR TITLE
feat(abacus): add currency field to transactions

### DIFF
--- a/backend/abacus/alembic/versions/b3c4d5e6f7a8_add_currency_to_transactions.py
+++ b/backend/abacus/alembic/versions/b3c4d5e6f7a8_add_currency_to_transactions.py
@@ -1,0 +1,33 @@
+"""add_currency_to_transactions
+
+Revision ID: b3c4d5e6f7a8
+Revises: a05bf0094fca
+Create Date: 2026-04-26 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = 'b3c4d5e6f7a8'
+down_revision: Union[str, None] = 'a05bf0094fca'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'transactions',
+        sa.Column('currency', sa.String(length=3), nullable=True),
+        schema='abacus',
+    )
+    op.execute("""
+        UPDATE abacus.transactions t
+        SET currency = (SELECT a.currency FROM abacus.assets a WHERE a.id = t.asset_id)
+    """)
+    op.alter_column('transactions', 'currency', nullable=False, schema='abacus')
+
+
+def downgrade() -> None:
+    op.drop_column('transactions', 'currency', schema='abacus')

--- a/backend/abacus/src/abacus/application/services/transaction_service.py
+++ b/backend/abacus/src/abacus/application/services/transaction_service.py
@@ -27,4 +27,6 @@ class TransactionService:
         if asset is None:
             raise NotFoundError("Asset", str(data["asset_id"]))
         data["user_id"] = user_id
+        if not data.get("currency"):
+            data["currency"] = asset.currency
         return await self._tx_repo.create(data)

--- a/backend/abacus/src/abacus/domain/models/transaction.py
+++ b/backend/abacus/src/abacus/domain/models/transaction.py
@@ -20,6 +20,7 @@ class Transaction(BaseModel):
     quantity: Decimal
     price_per_unit: Decimal
     fee: Decimal
+    currency: str
     broker: str | None
     notes: str | None
     created_at: datetime

--- a/backend/abacus/src/abacus/infrastructure/persistence/models.py
+++ b/backend/abacus/src/abacus/infrastructure/persistence/models.py
@@ -55,6 +55,7 @@ class TransactionModel(Base):
     fee: Mapped[Decimal] = mapped_column(
         Numeric(precision=20, scale=8), nullable=False, server_default="0"
     )
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
     broker: Mapped[str | None] = mapped_column(String(256), nullable=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(nullable=False, server_default=sa_func.now())

--- a/backend/abacus/src/abacus/presentation/schemas/transaction_schemas.py
+++ b/backend/abacus/src/abacus/presentation/schemas/transaction_schemas.py
@@ -14,6 +14,7 @@ class TransactionCreate(BaseModel):
     quantity: Decimal = Field(gt=0)
     price_per_unit: Decimal
     fee: Decimal = Decimal("0")
+    currency: str | None = None
     broker: str | None = None
     notes: str | None = None
 
@@ -26,6 +27,7 @@ class TransactionOut(BaseModel):
     quantity: Decimal
     price_per_unit: Decimal
     fee: Decimal
+    currency: str
     broker: str | None
     notes: str | None
     created_at: datetime

--- a/backend/abacus/tests/conftest.py
+++ b/backend/abacus/tests/conftest.py
@@ -48,6 +48,7 @@ def make_transaction(**kwargs: Any) -> Transaction:
         "quantity": Decimal("10"),
         "price_per_unit": Decimal("150.00"),
         "fee": Decimal("0"),
+        "currency": "USD",
         "broker": None,
         "notes": None,
         "created_at": now,

--- a/backend/abacus/tests/e2e/test_api.py
+++ b/backend/abacus/tests/e2e/test_api.py
@@ -100,6 +100,7 @@ async def test_create_transaction(
         "quantity": "10",
         "price_per_unit": "150.00",
         "fee": "0",
+        "currency": "USD",
         "broker": None,
         "notes": None,
     }
@@ -107,6 +108,7 @@ async def test_create_transaction(
     assert response.status_code == 201
     data = response.json()
     assert data["type"] == "buy"
+    assert data["currency"] == "USD"
 
 
 async def test_search_assets_returns_results(

--- a/backend/abacus/tests/unit/test_transaction_service.py
+++ b/backend/abacus/tests/unit/test_transaction_service.py
@@ -37,6 +37,7 @@ async def test_create_transaction_injects_user_id(
         "quantity": Decimal("10"),
         "price_per_unit": Decimal("150"),
         "fee": Decimal("0"),
+        "currency": "USD",
         "broker": None,
         "notes": None,
     }
@@ -45,6 +46,33 @@ async def test_create_transaction_injects_user_id(
     assert result == tx
     call_data = mock_transaction_repository.create.call_args[0][0]
     assert call_data["user_id"] == TEST_USER_ID
+
+
+async def test_create_transaction_defaults_currency_from_asset(
+    service: TransactionService,
+    mock_asset_repository: AsyncMock,
+    mock_transaction_repository: AsyncMock,
+) -> None:
+    asset = make_asset(currency="USD")
+    tx = make_transaction(currency="USD")
+    mock_asset_repository.get_by_id.return_value = asset
+    mock_transaction_repository.create.return_value = tx
+
+    data = {
+        "asset_id": TEST_ASSET_ID,
+        "date": tx.date,
+        "type": TransactionType.BUY,
+        "quantity": Decimal("10"),
+        "price_per_unit": Decimal("150"),
+        "fee": Decimal("0"),
+        "broker": None,
+        "notes": None,
+        # no currency provided
+    }
+    await service.create_transaction(TEST_USER_ID, data)
+
+    call_data = mock_transaction_repository.create.call_args[0][0]
+    assert call_data["currency"] == "USD"
 
 
 async def test_create_transaction_raises_if_asset_not_found(

--- a/frontend/abacus/src/components/TransactionForm.tsx
+++ b/frontend/abacus/src/components/TransactionForm.tsx
@@ -18,11 +18,18 @@ export default function TransactionForm({ assets, onSubmit, onAddAsset }: Props)
   const [quantity, setQuantity] = useState('')
   const [price, setPrice] = useState('')
   const [fee, setFee] = useState('0')
+  const [currency, setCurrency] = useState('')
   const [broker, setBroker] = useState('')
   const [notes, setNotes] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [showAssetModal, setShowAssetModal] = useState(false)
+
+  function handleAssetChange(id: string) {
+    setAssetId(id)
+    const asset = assets.find(a => a.id === id)
+    if (asset) setCurrency(asset.currency)
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
@@ -37,6 +44,7 @@ export default function TransactionForm({ assets, onSubmit, onAddAsset }: Props)
         quantity,
         price_per_unit: price,
         fee,
+        currency: currency || null,
         broker: broker || null,
         notes: notes || null,
       })
@@ -47,6 +55,7 @@ export default function TransactionForm({ assets, onSubmit, onAddAsset }: Props)
       setQuantity('')
       setPrice('')
       setFee('0')
+      setCurrency('')
       setBroker('')
       setNotes('')
     } catch (err) {
@@ -72,7 +81,7 @@ export default function TransactionForm({ assets, onSubmit, onAddAsset }: Props)
             <div className="flex gap-2">
               <select
                 value={assetId}
-                onChange={e => setAssetId(e.target.value)}
+                onChange={e => handleAssetChange(e.target.value)}
                 className="flex-1 bg-slate-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
                 <option value="">Selecciona…</option>
@@ -156,8 +165,8 @@ export default function TransactionForm({ assets, onSubmit, onAddAsset }: Props)
           </div>
         </div>
 
-        {/* Fee + broker */}
-        <div className="grid grid-cols-2 gap-3">
+        {/* Fee + currency + broker */}
+        <div className="grid grid-cols-3 gap-3">
           <div>
             <label className="block text-xs text-slate-400 mb-1">Comisión</label>
             <input
@@ -166,6 +175,16 @@ export default function TransactionForm({ assets, onSubmit, onAddAsset }: Props)
               step="any"
               value={fee}
               onChange={e => setFee(e.target.value)}
+              className="w-full bg-slate-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-xs text-slate-400 mb-1">Divisa</label>
+            <input
+              value={currency}
+              onChange={e => setCurrency(e.target.value.toUpperCase())}
+              placeholder="USD"
+              maxLength={3}
               className="w-full bg-slate-700 text-white rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>

--- a/frontend/abacus/src/components/TransactionList.tsx
+++ b/frontend/abacus/src/components/TransactionList.tsx
@@ -75,7 +75,7 @@ export default function TransactionList({
               <div className="text-right shrink-0">
                 <p className="text-sm text-slate-200">{formatQuantity(tx.quantity)}</p>
                 <p className="text-xs text-slate-400">
-                  {asset ? formatCurrency(tx.price_per_unit, asset.currency) : tx.price_per_unit}/u
+                  {formatCurrency(tx.price_per_unit, tx.currency)}/u
                 </p>
               </div>
 
@@ -83,11 +83,11 @@ export default function TransactionList({
               <div className="text-right shrink-0 w-24">
                 <p className={`text-sm font-medium ${isBuy ? 'text-red-400' : 'text-green-400'}`}>
                   {isBuy ? '−' : '+'}
-                  {asset ? formatCurrency(total, asset.currency) : total.toFixed(2)}
+                  {formatCurrency(total, tx.currency)}
                 </p>
                 {Number(tx.fee) > 0 && (
                   <p className="text-xs text-slate-500">
-                    com. {asset ? formatCurrency(tx.fee, asset.currency) : tx.fee}
+                    com. {formatCurrency(tx.fee, tx.currency)}
                   </p>
                 )}
               </div>

--- a/frontend/abacus/src/types/models.ts
+++ b/frontend/abacus/src/types/models.ts
@@ -20,6 +20,7 @@ export interface Transaction {
   quantity: string
   price_per_unit: string
   fee: string
+  currency: string
   broker: string | null
   notes: string | null
   created_at: string
@@ -61,6 +62,7 @@ export interface TransactionCreate {
   quantity: string
   price_per_unit: string
   fee: string
+  currency: string | null
   broker: string | null
   notes: string | null
 }


### PR DESCRIPTION
## Summary
- Adds `currency` column to the `transactions` table (Alembic migration backfills from asset currency, then sets NOT NULL)
- `TransactionCreate` accepts an optional `currency`; if omitted the service defaults to the asset's currency
- `TransactionForm` gains a **Divisa** input pre-filled from the selected asset (editable before submit)
- `TransactionList` now formats prices/totals using the transaction's own currency instead of the asset's

## Context
Some brokers (e.g. Trade Republic) execute USD-denominated stocks in EUR. Previously there was no way to record the actual execution currency; this makes it explicit.

## Changes
- `backend/abacus/alembic/versions/b3c4d5e6f7a8_add_currency_to_transactions.py` — migration
- `domain/models/transaction.py`, `infrastructure/persistence/models.py` — model field
- `presentation/schemas/transaction_schemas.py` — optional in, required out
- `application/services/transaction_service.py` — default from asset currency
- `frontend/abacus/src/types/models.ts` — TS types updated
- `frontend/abacus/src/components/TransactionForm.tsx` — Divisa input added
- `frontend/abacus/src/components/TransactionList.tsx` — uses `tx.currency`

## Testing
- 32/32 backend tests pass (`make test APP=abacus`)
- Frontend lint, typecheck, and vitest all pass

## Test Plan
1. `make dev APP=abacus`
2. Login and open the transaction form
3. Select an asset → **Divisa** field auto-fills with the asset's currency
4. Override the currency (e.g. change USD → EUR) and submit
5. Verify the transaction list shows prices formatted in EUR
6. Submit a transaction without modifying the currency → should default to the asset's currency

🤖 Generated with [Claude Code](https://claude.com/claude-code)