### PR TITLE
feat(abacus): realized P&L with buy↔sell linking (#20)

### DIFF
--- a/backend/abacus/alembic/versions/c1d2e3f4a5b6_add_transaction_links.py
+++ b/backend/abacus/alembic/versions/c1d2e3f4a5b6_add_transaction_links.py
@@ -1,0 +1,53 @@
+"""add transaction links
+
+Revision ID: c1d2e3f4a5b6
+Revises: b3c4d5e6f7a8
+Create Date: 2026-04-26 00:00:00.000000
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: str | None = "b3c4d5e6f7a8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SCHEMA = "abacus"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "transaction_links",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "sell_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(f"{_SCHEMA}.transactions.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "buy_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(f"{_SCHEMA}.transactions.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("quantity", sa.Numeric(precision=20, scale=8), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("sell_id", "buy_id", name="uq_transaction_link_sell_buy"),
+        sa.CheckConstraint("quantity > 0", name="ck_transaction_link_quantity_positive"),
+        schema=_SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("transaction_links", schema=_SCHEMA)

--- a/backend/abacus/src/abacus/application/services/pnl.py
+++ b/backend/abacus/src/abacus/application/services/pnl.py
@@ -1,0 +1,43 @@
+import uuid
+from dataclasses import dataclass
+from decimal import Decimal
+
+from abacus.domain.models.transaction import Transaction
+from abacus.domain.models.transaction_link import TransactionLink
+
+
+@dataclass
+class RealizedPnL:
+    pnl: Decimal
+    cost_basis: Decimal
+    pnl_pct: Decimal | None
+    unlinked_quantity: Decimal
+
+
+def compute_pnl(
+    sell: Transaction,
+    links: list[TransactionLink],
+    buys_by_id: dict[uuid.UUID, Transaction],
+) -> RealizedPnL:
+    total_linked = Decimal("0")
+    cost_basis = Decimal("0")
+    proceeds = Decimal("0")
+
+    for link in links:
+        buy = buys_by_id[link.buy_id]
+        qty = link.quantity
+        total_linked += qty
+
+        buy_fee_alloc = buy.fee * (qty / buy.quantity)
+        sell_fee_alloc = sell.fee * (qty / sell.quantity) if sell.quantity else Decimal("0")
+
+        cost_basis += buy.price_per_unit * qty + buy_fee_alloc
+        proceeds += sell.price_per_unit * qty - sell_fee_alloc
+
+    pnl = proceeds - cost_basis
+    pnl_pct = (pnl / cost_basis * Decimal("100")) if cost_basis else None
+    unlinked_quantity = sell.quantity - total_linked
+
+    return RealizedPnL(
+        pnl=pnl, cost_basis=cost_basis, pnl_pct=pnl_pct, unlinked_quantity=unlinked_quantity
+    )

--- a/backend/abacus/src/abacus/application/services/transaction_service.py
+++ b/backend/abacus/src/abacus/application/services/transaction_service.py
@@ -1,9 +1,16 @@
 import uuid
+from decimal import Decimal
 from typing import Any
 
-from abacus.domain.exceptions import NotFoundError
-from abacus.domain.models.transaction import Transaction
-from abacus.domain.ports.repositories import AssetRepository, TransactionRepository
+from abacus.application.services.pnl import RealizedPnL, compute_pnl
+from abacus.domain.exceptions import LinkValidationError, NotFoundError
+from abacus.domain.models.transaction import Transaction, TransactionType
+from abacus.domain.models.transaction_link import TransactionLink
+from abacus.domain.ports.repositories import (
+    AssetRepository,
+    TransactionLinkRepository,
+    TransactionRepository,
+)
 
 
 class TransactionService:
@@ -11,9 +18,11 @@ class TransactionService:
         self,
         asset_repository: AssetRepository,
         transaction_repository: TransactionRepository,
+        link_repository: TransactionLinkRepository,
     ) -> None:
         self._asset_repo = asset_repository
         self._tx_repo = transaction_repository
+        self._link_repo = link_repository
 
     async def list_transactions(
         self, user_id: uuid.UUID, limit: int = 50, offset: int = 0
@@ -22,6 +31,29 @@ class TransactionService:
         total = await self._tx_repo.count_by_user(user_id)
         return transactions, total
 
+    async def list_transactions_enriched(
+        self, user_id: uuid.UUID, limit: int = 50, offset: int = 0
+    ) -> tuple[list[tuple[Transaction, list[TransactionLink], RealizedPnL | None]], int]:
+        transactions, total = await self.list_transactions(user_id, limit, offset)
+        sell_ids = [tx.id for tx in transactions if tx.type == TransactionType.SELL]
+        all_links = await self._tx_repo.get_links_for_sells(sell_ids)
+        links_by_sell: dict[uuid.UUID, list[TransactionLink]] = {}
+        for lnk in all_links:
+            links_by_sell.setdefault(lnk.sell_id, []).append(lnk)
+        buy_ids = {lnk.buy_id for lnk in all_links}
+        buys = await self._tx_repo.list_by_ids(list(buy_ids), user_id)
+        buys_by_id = {b.id: b for b in buys}
+
+        result = []
+        for tx in transactions:
+            if tx.type == TransactionType.SELL:
+                links = links_by_sell.get(tx.id, [])
+                pnl = compute_pnl(tx, links, buys_by_id)
+                result.append((tx, links, pnl))
+            else:
+                result.append((tx, [], None))
+        return result, total
+
     async def create_transaction(self, user_id: uuid.UUID, data: dict[str, Any]) -> Transaction:
         asset = await self._asset_repo.get_by_id(data["asset_id"], user_id)
         if asset is None:
@@ -29,4 +61,163 @@ class TransactionService:
         data["user_id"] = user_id
         if not data.get("currency"):
             data["currency"] = asset.currency
-        return await self._tx_repo.create(data)
+        tx = await self._tx_repo.create(data)
+        if tx.type == TransactionType.SELL:
+            await self._auto_link_fifo(tx)
+        return tx
+
+    async def _auto_link_fifo(self, sell: Transaction) -> None:
+        open_buys = await self._tx_repo.list_open_buys(sell.user_id, sell.asset_id, sell.currency)
+        remaining = sell.quantity
+        links: list[tuple[uuid.UUID, Decimal]] = []
+        for buy, buy_remaining in open_buys:
+            if remaining <= 0:
+                break
+            allocated = min(remaining, buy_remaining)
+            links.append((buy.id, allocated))
+            remaining -= allocated
+        await self._link_repo.replace_links_for_sell(sell.id, links)
+
+    async def update_sell_links(
+        self,
+        user_id: uuid.UUID,
+        sell_id: uuid.UUID,
+        links_payload: list[tuple[uuid.UUID, Decimal]],
+    ) -> tuple[Transaction, list[TransactionLink], RealizedPnL]:
+        sell = await self._tx_repo.get_by_id(sell_id, user_id)
+        if sell is None:
+            raise NotFoundError("Transaction", str(sell_id))
+
+        buys_by_id: dict[uuid.UUID, Transaction] = {}
+        qty_per_buy: dict[uuid.UUID, Decimal] = {}
+        total_sell_qty = Decimal("0")
+
+        for buy_id, qty in links_payload:
+            buy = await self._tx_repo.get_by_id(buy_id, user_id)
+            if buy is None:
+                raise NotFoundError("Transaction", str(buy_id))
+            if buy.currency != sell.currency:
+                raise LinkValidationError(
+                    f"currency mismatch: buy {buy.currency!r} != sell {sell.currency!r}"
+                )
+            if buy.asset_id != sell.asset_id:
+                raise LinkValidationError(
+                    f"asset mismatch: buy asset {buy.asset_id} != sell asset {sell.asset_id}"
+                )
+            if buy.date > sell.date:
+                raise LinkValidationError(
+                    f"date: buy date {buy.date} is after sell date {sell.date}"
+                )
+            already_allocated = await self._link_repo.get_allocated_for_buy_excluding_sell(
+                buy_id, sell_id
+            )
+            if already_allocated + qty > buy.quantity:
+                raise LinkValidationError(
+                    f"overallocated: buy {buy_id} has {buy.quantity} units but "
+                    f"{already_allocated + qty} would be allocated"
+                )
+            buys_by_id[buy_id] = buy
+            qty_per_buy[buy_id] = qty_per_buy.get(buy_id, Decimal("0")) + qty
+            total_sell_qty += qty
+
+        if total_sell_qty > sell.quantity:
+            raise LinkValidationError(
+                f"quantity: links total {total_sell_qty} exceeds sell quantity {sell.quantity}"
+            )
+
+        links = await self._link_repo.replace_links_for_sell(
+            sell_id, [(buy_id, qty) for buy_id, qty in qty_per_buy.items()]
+        )
+        pnl = compute_pnl(sell, links, buys_by_id)
+        return sell, links, pnl
+
+    async def get_available_buys_for_sell(
+        self, user_id: uuid.UUID, sell_id: uuid.UUID
+    ) -> tuple[Transaction, list[tuple[Transaction, Decimal, Decimal]]]:
+        """Returns (sell, [(buy, qty_available_for_this_sell, qty_currently_linked)])."""
+        sell = await self._tx_repo.get_by_id(sell_id, user_id)
+        if sell is None:
+            raise NotFoundError("Transaction", str(sell_id))
+        # Buys where remaining > 0, computed excluding all links
+        open_buys = await self._tx_repo.list_open_buys(sell.user_id, sell.asset_id, sell.currency)
+        # Current links from this sell to each buy
+        current_links = await self._tx_repo.get_links_by_sell(sell_id)
+        linked_by_buy = {lnk.buy_id: lnk.quantity for lnk in current_links}
+
+        # Also include buys that are fully consumed by THIS sell but not open otherwise
+        already_linked_buy_ids = set(linked_by_buy.keys())
+        open_buy_ids = {buy.id for buy, _ in open_buys}
+        missing_buy_ids = already_linked_buy_ids - open_buy_ids
+        extra_buys: list[tuple[Transaction, Decimal, Decimal]] = []
+        if missing_buy_ids:
+            extra = await self._tx_repo.list_by_ids(list(missing_buy_ids), user_id)
+            for b in extra:
+                linked_qty = linked_by_buy.get(b.id, Decimal("0"))
+                extra_buys.append((b, linked_qty, linked_qty))
+
+        rows: list[tuple[Transaction, Decimal, Decimal]] = []
+        for buy, qty_remaining in open_buys:
+            if buy.date > sell.date:
+                continue
+            linked_qty = linked_by_buy.get(buy.id, Decimal("0"))
+            available = qty_remaining + linked_qty  # add back what THIS sell consumed
+            rows.append((buy, available, linked_qty))
+
+        return sell, rows + extra_buys
+
+    async def compute_summary_by_asset(
+        self, user_id: uuid.UUID
+    ) -> list[dict]:
+        enriched, _ = await self.list_transactions_enriched(user_id, limit=1000, offset=0)
+        summaries: dict[uuid.UUID, dict] = {}
+        for tx, _links, pnl in enriched:
+            if tx.type != TransactionType.SELL or pnl is None:
+                continue
+            entry = summaries.setdefault(
+                tx.asset_id,
+                {
+                    "asset_id": tx.asset_id,
+                    "currency": tx.currency,
+                    "realized_pnl": Decimal("0"),
+                    "cost_basis": Decimal("0"),
+                    "sells_count": 0,
+                },
+            )
+            entry["realized_pnl"] += pnl.pnl
+            entry["cost_basis"] += pnl.cost_basis
+            entry["sells_count"] += 1
+
+        # Enrich with asset info
+        results = []
+        for asset_id, entry in summaries.items():
+            asset = await self._asset_repo.get_by_id(asset_id, user_id)
+            pnl_pct = (
+                entry["realized_pnl"] / entry["cost_basis"] * Decimal("100")
+                if entry["cost_basis"]
+                else None
+            )
+            results.append(
+                {
+                    **entry,
+                    "asset_ticker": asset.ticker if asset else None,
+                    "asset_name": asset.name if asset else str(asset_id),
+                    "realized_pnl_pct": pnl_pct,
+                }
+            )
+        return results
+
+    async def get_sell_pnl(
+        self, sell: Transaction
+    ) -> tuple[list[TransactionLink], RealizedPnL] | None:
+        if sell.type != TransactionType.SELL:
+            return None
+        links = await self._tx_repo.get_links_by_sell(sell.id)
+        if not links:
+            return links, compute_pnl(sell, [], {})
+        buy_ids = {lnk.buy_id for lnk in links}
+        buys_by_id: dict[uuid.UUID, Transaction] = {}
+        for buy_id in buy_ids:
+            buy = await self._tx_repo.get_by_id(buy_id, sell.user_id)
+            if buy:
+                buys_by_id[buy_id] = buy
+        return links, compute_pnl(sell, links, buys_by_id)

--- a/backend/abacus/src/abacus/application/services/transaction_service.py
+++ b/backend/abacus/src/abacus/application/services/transaction_service.py
@@ -44,11 +44,11 @@ class TransactionService:
         buys = await self._tx_repo.list_by_ids(list(buy_ids), user_id)
         buys_by_id = {b.id: b for b in buys}
 
-        result = []
+        result: list[tuple[Transaction, list[TransactionLink], RealizedPnL | None]] = []
         for tx in transactions:
             if tx.type == TransactionType.SELL:
                 links = links_by_sell.get(tx.id, [])
-                pnl = compute_pnl(tx, links, buys_by_id)
+                pnl: RealizedPnL | None = compute_pnl(tx, links, buys_by_id)
                 result.append((tx, links, pnl))
             else:
                 result.append((tx, [], None))
@@ -167,9 +167,9 @@ class TransactionService:
 
     async def compute_summary_by_asset(
         self, user_id: uuid.UUID
-    ) -> list[dict]:
+    ) -> list[dict[str, Any]]:
         enriched, _ = await self.list_transactions_enriched(user_id, limit=1000, offset=0)
-        summaries: dict[uuid.UUID, dict] = {}
+        summaries: dict[uuid.UUID, dict[str, Any]] = {}
         for tx, _links, pnl in enriched:
             if tx.type != TransactionType.SELL or pnl is None:
                 continue

--- a/backend/abacus/src/abacus/domain/exceptions.py
+++ b/backend/abacus/src/abacus/domain/exceptions.py
@@ -23,3 +23,7 @@ class StockSearchUnavailableError(DomainError):
 
 class ExternalServiceError(DomainError):
     pass
+
+
+class LinkValidationError(DomainError):
+    pass

--- a/backend/abacus/src/abacus/domain/models/transaction_link.py
+++ b/backend/abacus/src/abacus/domain/models/transaction_link.py
@@ -1,0 +1,15 @@
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class TransactionLink(BaseModel):
+    id: uuid.UUID
+    sell_id: uuid.UUID
+    buy_id: uuid.UUID
+    quantity: Decimal
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/abacus/src/abacus/domain/ports/repositories.py
+++ b/backend/abacus/src/abacus/domain/ports/repositories.py
@@ -1,8 +1,10 @@
 import uuid
+from decimal import Decimal
 from typing import Any, Protocol
 
 from abacus.domain.models.asset import Asset
 from abacus.domain.models.transaction import Transaction
+from abacus.domain.models.transaction_link import TransactionLink
 
 
 class AssetRepository(Protocol):
@@ -20,6 +22,32 @@ class TransactionRepository(Protocol):
         self, user_id: uuid.UUID, limit: int, offset: int
     ) -> list[Transaction]: ...
 
+    async def get_by_id(
+        self, transaction_id: uuid.UUID, user_id: uuid.UUID
+    ) -> Transaction | None: ...
+
     async def create(self, data: dict[str, Any]) -> Transaction: ...
 
     async def count_by_user(self, user_id: uuid.UUID) -> int: ...
+
+    async def list_open_buys(
+        self, user_id: uuid.UUID, asset_id: uuid.UUID, currency: str
+    ) -> list[tuple[Transaction, Decimal]]: ...
+
+    async def get_links_by_sell(self, sell_id: uuid.UUID) -> list[TransactionLink]: ...
+
+    async def get_links_by_user(self, user_id: uuid.UUID) -> list[TransactionLink]: ...
+
+    async def get_links_for_sells(self, sell_ids: list[uuid.UUID]) -> list[TransactionLink]: ...
+
+    async def list_by_ids(self, ids: list[uuid.UUID], user_id: uuid.UUID) -> list[Transaction]: ...
+
+
+class TransactionLinkRepository(Protocol):
+    async def replace_links_for_sell(
+        self, sell_id: uuid.UUID, links: list[tuple[uuid.UUID, Decimal]]
+    ) -> list[TransactionLink]: ...
+
+    async def get_allocated_for_buy_excluding_sell(
+        self, buy_id: uuid.UUID, sell_id: uuid.UUID
+    ) -> Decimal: ...

--- a/backend/abacus/src/abacus/infrastructure/persistence/models.py
+++ b/backend/abacus/src/abacus/infrastructure/persistence/models.py
@@ -2,7 +2,16 @@ import uuid
 from datetime import date, datetime
 from decimal import Decimal
 
-from sqlalchemy import Date, Enum, ForeignKey, Numeric, String, Text
+from sqlalchemy import (
+    CheckConstraint,
+    Date,
+    Enum,
+    ForeignKey,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
 from sqlalchemy import func as sa_func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -64,3 +73,37 @@ class TransactionModel(Base):
     )
 
     asset: Mapped["AssetModel"] = relationship(back_populates="transactions")
+    sell_links: Mapped[list["TransactionLinkModel"]] = relationship(
+        "TransactionLinkModel",
+        foreign_keys="TransactionLinkModel.sell_id",
+        cascade="all, delete-orphan",
+    )
+    buy_links: Mapped[list["TransactionLinkModel"]] = relationship(
+        "TransactionLinkModel",
+        foreign_keys="TransactionLinkModel.buy_id",
+    )
+
+
+class TransactionLinkModel(Base):
+    __tablename__ = "transaction_links"
+    __table_args__ = (
+        UniqueConstraint("sell_id", "buy_id", name="uq_transaction_link_sell_buy"),
+        CheckConstraint("quantity > 0", name="ck_transaction_link_quantity_positive"),
+        {"schema": _SCHEMA},
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    sell_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(f"{_SCHEMA}.transactions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    buy_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey(f"{_SCHEMA}.transactions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    quantity: Mapped[Decimal] = mapped_column(Numeric(precision=20, scale=8), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(nullable=False, server_default=sa_func.now())

--- a/backend/abacus/src/abacus/infrastructure/persistence/repositories/sqlalchemy_transaction_link_repository.py
+++ b/backend/abacus/src/abacus/infrastructure/persistence/repositories/sqlalchemy_transaction_link_repository.py
@@ -1,0 +1,42 @@
+import uuid
+from decimal import Decimal
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from abacus.domain.models.transaction_link import TransactionLink
+from abacus.infrastructure.persistence.models import TransactionLinkModel
+
+
+class SQLAlchemyTransactionLinkRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def replace_links_for_sell(
+        self, sell_id: uuid.UUID, links: list[tuple[uuid.UUID, Decimal]]
+    ) -> list[TransactionLink]:
+        await self._session.execute(
+            delete(TransactionLinkModel).where(TransactionLinkModel.sell_id == sell_id)
+        )
+        rows = []
+        for buy_id, quantity in links:
+            row = TransactionLinkModel(
+                id=uuid.uuid4(), sell_id=sell_id, buy_id=buy_id, quantity=quantity
+            )
+            self._session.add(row)
+            rows.append(row)
+        await self._session.flush()
+        for row in rows:
+            await self._session.refresh(row)
+        return [TransactionLink.model_validate(row) for row in rows]
+
+    async def get_allocated_for_buy_excluding_sell(
+        self, buy_id: uuid.UUID, sell_id: uuid.UUID
+    ) -> Decimal:
+        result = await self._session.execute(
+            select(func.coalesce(func.sum(TransactionLinkModel.quantity), Decimal("0"))).where(
+                TransactionLinkModel.buy_id == buy_id,
+                TransactionLinkModel.sell_id != sell_id,
+            )
+        )
+        return result.scalar_one()

--- a/backend/abacus/src/abacus/infrastructure/persistence/repositories/sqlalchemy_transaction_repository.py
+++ b/backend/abacus/src/abacus/infrastructure/persistence/repositories/sqlalchemy_transaction_repository.py
@@ -72,7 +72,10 @@ class SQLAlchemyTransactionRepository:
         result = await self._session.execute(stmt)
         rows = result.all()
         return [
-            (Transaction.model_validate(row.TransactionModel), row.quantity - row.linked_qty)
+            (
+                Transaction.model_validate(row.TransactionModel),
+                row.TransactionModel.quantity - row.linked_qty,
+            )
             for row in rows
         ]
 

--- a/backend/abacus/src/abacus/infrastructure/persistence/repositories/sqlalchemy_transaction_repository.py
+++ b/backend/abacus/src/abacus/infrastructure/persistence/repositories/sqlalchemy_transaction_repository.py
@@ -1,11 +1,13 @@
 import uuid
+from decimal import Decimal
 from typing import Any
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from abacus.domain.models.transaction import Transaction
-from abacus.infrastructure.persistence.models import TransactionModel
+from abacus.domain.models.transaction import Transaction, TransactionType
+from abacus.domain.models.transaction_link import TransactionLink
+from abacus.infrastructure.persistence.models import TransactionLinkModel, TransactionModel
 
 
 class SQLAlchemyTransactionRepository:
@@ -22,6 +24,16 @@ class SQLAlchemyTransactionRepository:
         )
         return [Transaction.model_validate(row) for row in result.scalars().all()]
 
+    async def get_by_id(self, transaction_id: uuid.UUID, user_id: uuid.UUID) -> Transaction | None:
+        result = await self._session.execute(
+            select(TransactionModel).where(
+                TransactionModel.id == transaction_id,
+                TransactionModel.user_id == user_id,
+            )
+        )
+        row = result.scalar_one_or_none()
+        return Transaction.model_validate(row) if row else None
+
     async def create(self, data: dict[str, Any]) -> Transaction:
         row = TransactionModel(**data)
         self._session.add(row)
@@ -34,3 +46,65 @@ class SQLAlchemyTransactionRepository:
             select(func.count()).where(TransactionModel.user_id == user_id)
         )
         return result.scalar_one()
+
+    async def list_open_buys(
+        self, user_id: uuid.UUID, asset_id: uuid.UUID, currency: str
+    ) -> list[tuple[Transaction, Decimal]]:
+        linked_qty = func.coalesce(func.sum(TransactionLinkModel.quantity), Decimal("0")).label(
+            "linked_qty"
+        )
+        stmt = (
+            select(TransactionModel, linked_qty)
+            .outerjoin(
+                TransactionLinkModel,
+                TransactionLinkModel.buy_id == TransactionModel.id,
+            )
+            .where(
+                TransactionModel.user_id == user_id,
+                TransactionModel.asset_id == asset_id,
+                TransactionModel.currency == currency,
+                TransactionModel.type == TransactionType.BUY,
+            )
+            .group_by(TransactionModel.id)
+            .having(TransactionModel.quantity - linked_qty > 0)
+            .order_by(TransactionModel.date.asc(), TransactionModel.created_at.asc())
+        )
+        result = await self._session.execute(stmt)
+        rows = result.all()
+        return [
+            (Transaction.model_validate(row.TransactionModel), row.quantity - row.linked_qty)
+            for row in rows
+        ]
+
+    async def get_links_by_sell(self, sell_id: uuid.UUID) -> list[TransactionLink]:
+        result = await self._session.execute(
+            select(TransactionLinkModel).where(TransactionLinkModel.sell_id == sell_id)
+        )
+        return [TransactionLink.model_validate(row) for row in result.scalars().all()]
+
+    async def get_links_by_user(self, user_id: uuid.UUID) -> list[TransactionLink]:
+        result = await self._session.execute(
+            select(TransactionLinkModel)
+            .join(TransactionModel, TransactionModel.id == TransactionLinkModel.sell_id)
+            .where(TransactionModel.user_id == user_id)
+        )
+        return [TransactionLink.model_validate(row) for row in result.scalars().all()]
+
+    async def get_links_for_sells(self, sell_ids: list[uuid.UUID]) -> list[TransactionLink]:
+        if not sell_ids:
+            return []
+        result = await self._session.execute(
+            select(TransactionLinkModel).where(TransactionLinkModel.sell_id.in_(sell_ids))
+        )
+        return [TransactionLink.model_validate(row) for row in result.scalars().all()]
+
+    async def list_by_ids(self, ids: list[uuid.UUID], user_id: uuid.UUID) -> list[Transaction]:
+        if not ids:
+            return []
+        result = await self._session.execute(
+            select(TransactionModel).where(
+                TransactionModel.id.in_(ids),
+                TransactionModel.user_id == user_id,
+            )
+        )
+        return [Transaction.model_validate(row) for row in result.scalars().all()]

--- a/backend/abacus/src/abacus/presentation/api/transactions.py
+++ b/backend/abacus/src/abacus/presentation/api/transactions.py
@@ -1,7 +1,9 @@
 import uuid
+from collections.abc import Sequence
 
 from fastapi import APIRouter, HTTPException, Query
 
+from abacus.application.services.pnl import RealizedPnL
 from abacus.domain.exceptions import LinkValidationError, NotFoundError
 from abacus.presentation.dependencies import CurrentUser, TransactionServiceDep
 from abacus.presentation.schemas.transaction_schemas import (
@@ -18,7 +20,9 @@ from abacus.presentation.schemas.transaction_schemas import (
 router = APIRouter(prefix="/transactions", tags=["transactions"])
 
 
-def _enrich(tx: object, links: list, pnl: object | None) -> TransactionOut:
+def _enrich(
+    tx: object, links: Sequence[object], pnl: RealizedPnL | None
+) -> TransactionOut:
     tx_out = TransactionOut.model_validate(tx)
     if pnl is not None:
         tx_out.realized_pnl = pnl.pnl

--- a/backend/abacus/src/abacus/presentation/api/transactions.py
+++ b/backend/abacus/src/abacus/presentation/api/transactions.py
@@ -1,13 +1,32 @@
-from fastapi import APIRouter, Query
+import uuid
 
+from fastapi import APIRouter, HTTPException, Query
+
+from abacus.domain.exceptions import LinkValidationError, NotFoundError
 from abacus.presentation.dependencies import CurrentUser, TransactionServiceDep
 from abacus.presentation.schemas.transaction_schemas import (
+    AssetPnLSummary,
+    AvailableBuyOut,
+    AvailableBuysResponse,
+    LinksUpdateRequest,
     PaginatedTransactions,
     TransactionCreate,
+    TransactionLinkOut,
     TransactionOut,
 )
 
 router = APIRouter(prefix="/transactions", tags=["transactions"])
+
+
+def _enrich(tx: object, links: list, pnl: object | None) -> TransactionOut:
+    tx_out = TransactionOut.model_validate(tx)
+    if pnl is not None:
+        tx_out.realized_pnl = pnl.pnl
+        tx_out.realized_pnl_pct = pnl.pnl_pct
+        tx_out.cost_basis = pnl.cost_basis
+        tx_out.unlinked_quantity = pnl.unlinked_quantity
+        tx_out.links = [TransactionLinkOut.model_validate(lnk) for lnk in links]
+    return tx_out
 
 
 @router.post("/", response_model=TransactionOut, status_code=201)
@@ -27,10 +46,58 @@ async def list_transactions(
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
 ) -> PaginatedTransactions:
-    items, total = await service.list_transactions(user_id, limit, offset)
+    enriched, total = await service.list_transactions_enriched(user_id, limit, offset)
     return PaginatedTransactions(
-        items=[TransactionOut.model_validate(tx) for tx in items],
+        items=[_enrich(tx, links, pnl) for tx, links, pnl in enriched],
         total=total,
         limit=limit,
         offset=offset,
     )
+
+
+@router.get("/{sell_id}/available-buys", response_model=AvailableBuysResponse)
+async def get_available_buys(
+    sell_id: uuid.UUID,
+    service: TransactionServiceDep,
+    user_id: CurrentUser,
+) -> AvailableBuysResponse:
+    try:
+        sell, rows = await service.get_available_buys_for_sell(user_id, sell_id)
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    return AvailableBuysResponse(
+        sell=TransactionOut.model_validate(sell),
+        available_buys=[
+            AvailableBuyOut(
+                buy=TransactionOut.model_validate(buy),
+                qty_available=qty_avail,
+                qty_linked=qty_linked,
+            )
+            for buy, qty_avail, qty_linked in rows
+        ],
+    )
+
+
+@router.get("/summary/by-asset", response_model=list[AssetPnLSummary])
+async def get_summary_by_asset(
+    service: TransactionServiceDep,
+    user_id: CurrentUser,
+) -> list[AssetPnLSummary]:
+    rows = await service.compute_summary_by_asset(user_id)
+    return [AssetPnLSummary(**row) for row in rows]
+
+
+@router.put("/{sell_id}/links", response_model=TransactionOut)
+async def update_sell_links(
+    sell_id: uuid.UUID,
+    body: LinksUpdateRequest,
+    service: TransactionServiceDep,
+    user_id: CurrentUser,
+) -> TransactionOut:
+    try:
+        sell, links, pnl = await service.update_sell_links(user_id, sell_id, body.links)
+    except NotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except LinkValidationError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    return _enrich(sell, links, pnl)

--- a/backend/abacus/src/abacus/presentation/dependencies.py
+++ b/backend/abacus/src/abacus/presentation/dependencies.py
@@ -15,6 +15,9 @@ from abacus.infrastructure.persistence.database import get_session
 from abacus.infrastructure.persistence.repositories.sqlalchemy_asset_repository import (
     SQLAlchemyAssetRepository,
 )
+from abacus.infrastructure.persistence.repositories.sqlalchemy_transaction_link_repository import (
+    SQLAlchemyTransactionLinkRepository,
+)
 from abacus.infrastructure.persistence.repositories.sqlalchemy_transaction_repository import (
     SQLAlchemyTransactionRepository,
 )
@@ -45,7 +48,12 @@ def get_asset_service(session: SessionDep, port: StockSearchPortDep) -> AssetSer
 def get_transaction_service(session: SessionDep) -> TransactionService:
     asset_repo = SQLAlchemyAssetRepository(session)
     tx_repo = SQLAlchemyTransactionRepository(session)
-    return TransactionService(asset_repository=asset_repo, transaction_repository=tx_repo)
+    link_repo = SQLAlchemyTransactionLinkRepository(session)
+    return TransactionService(
+        asset_repository=asset_repo,
+        transaction_repository=tx_repo,
+        link_repository=link_repo,
+    )
 
 
 AssetServiceDep = Annotated[AssetService, Depends(get_asset_service)]

--- a/backend/abacus/src/abacus/presentation/schemas/transaction_schemas.py
+++ b/backend/abacus/src/abacus/presentation/schemas/transaction_schemas.py
@@ -19,6 +19,16 @@ class TransactionCreate(BaseModel):
     notes: str | None = None
 
 
+class TransactionLinkOut(BaseModel):
+    id: uuid.UUID
+    sell_id: uuid.UUID
+    buy_id: uuid.UUID
+    quantity: Decimal
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
 class TransactionOut(BaseModel):
     id: uuid.UUID
     asset_id: uuid.UUID
@@ -32,6 +42,12 @@ class TransactionOut(BaseModel):
     notes: str | None
     created_at: datetime
     updated_at: datetime
+    # P&L fields — only populated for SELL transactions
+    realized_pnl: Decimal | None = None
+    realized_pnl_pct: Decimal | None = None
+    cost_basis: Decimal | None = None
+    unlinked_quantity: Decimal | None = None
+    links: list[TransactionLinkOut] = []
 
     model_config = {"from_attributes": True}
 
@@ -41,3 +57,29 @@ class PaginatedTransactions(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+class LinksUpdateRequest(BaseModel):
+    links: list[tuple[uuid.UUID, Decimal]]
+
+
+class AvailableBuyOut(BaseModel):
+    buy: TransactionOut
+    qty_available: Decimal
+    qty_linked: Decimal
+
+
+class AvailableBuysResponse(BaseModel):
+    sell: TransactionOut
+    available_buys: list[AvailableBuyOut]
+
+
+class AssetPnLSummary(BaseModel):
+    asset_id: uuid.UUID
+    asset_ticker: str | None
+    asset_name: str
+    currency: str
+    realized_pnl: Decimal
+    cost_basis: Decimal
+    realized_pnl_pct: Decimal | None
+    sells_count: int

--- a/backend/abacus/tests/e2e/test_api.py
+++ b/backend/abacus/tests/e2e/test_api.py
@@ -1,3 +1,5 @@
+import uuid
+from decimal import Decimal
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -7,9 +9,16 @@ from abacus.application.services.asset_service import AssetService
 from abacus.application.services.transaction_service import TransactionService
 from abacus.domain.models.asset import AssetClass
 from abacus.domain.models.stock_search import StockSearchResult
+from abacus.domain.models.transaction import TransactionType
+from abacus.domain.models.transaction_link import TransactionLink
 from abacus.main import app
 from abacus.presentation.dependencies import get_asset_service, get_transaction_service
-from tests.conftest import make_asset, make_transaction
+from tests.conftest import TEST_ASSET_ID, make_asset, make_transaction
+
+
+@pytest.fixture
+def mock_link_repository() -> AsyncMock:
+    return AsyncMock()
 
 
 @pytest.fixture(autouse=True)
@@ -17,6 +26,7 @@ def override_services(
     mock_asset_repository: AsyncMock,
     mock_transaction_repository: AsyncMock,
     mock_stock_search_port: AsyncMock,
+    mock_link_repository: AsyncMock,
 ) -> Any:
     """Override service dependencies with mock-backed instances."""
 
@@ -29,6 +39,7 @@ def override_services(
         return TransactionService(
             asset_repository=mock_asset_repository,
             transaction_repository=mock_transaction_repository,
+            link_repository=mock_link_repository,
         )
 
     app.dependency_overrides[get_asset_service] = _asset_service
@@ -133,9 +144,7 @@ async def test_search_assets_requires_query(async_client: Any) -> None:
     assert response.status_code == 422
 
 
-async def test_get_asset_profile(
-    async_client: Any, mock_stock_search_port: AsyncMock
-) -> None:
+async def test_get_asset_profile(async_client: Any, mock_stock_search_port: AsyncMock) -> None:
     from abacus.domain.models.stock_search import StockProfile
 
     mock_stock_search_port.get_profile.return_value = StockProfile(
@@ -159,6 +168,135 @@ async def test_get_asset_profile_returns_null_when_not_found(
 
     assert response.status_code == 200
     assert response.json() is None
+
+
+async def test_list_transactions_sell_has_pnl_fields(
+    async_client: Any,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    buy = make_transaction(
+        type=TransactionType.BUY,
+        quantity=Decimal("10"),
+        price_per_unit=Decimal("100"),
+        fee=Decimal("0"),
+    )
+    sell = make_transaction(
+        type=TransactionType.SELL,
+        quantity=Decimal("10"),
+        price_per_unit=Decimal("120"),
+        fee=Decimal("0"),
+    )
+    mock_transaction_repository.list_by_user.return_value = [sell, buy]
+    mock_transaction_repository.count_by_user.return_value = 2
+    link = TransactionLink(
+        id=uuid.uuid4(),
+        sell_id=sell.id,
+        buy_id=buy.id,
+        quantity=Decimal("10"),
+        created_at=sell.created_at,
+    )
+    mock_transaction_repository.get_links_for_sells.return_value = [link]
+    mock_transaction_repository.list_by_ids.return_value = [buy]
+
+    response = await async_client.get("/api/transactions/")
+    assert response.status_code == 200
+    items = response.json()["items"]
+    sell_item = next(i for i in items if i["type"] == "sell")
+    assert sell_item["realized_pnl"] == "200"
+    assert sell_item["unlinked_quantity"] == "0"
+
+
+async def test_update_sell_links_returns_pnl(
+    async_client: Any,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    buy = make_transaction(
+        type=TransactionType.BUY,
+        quantity=Decimal("10"),
+        price_per_unit=Decimal("100"),
+        fee=Decimal("0"),
+        asset_id=TEST_ASSET_ID,
+    )
+    sell = make_transaction(
+        type=TransactionType.SELL,
+        quantity=Decimal("10"),
+        price_per_unit=Decimal("120"),
+        fee=Decimal("0"),
+        asset_id=TEST_ASSET_ID,
+    )
+    mock_transaction_repository.get_by_id.side_effect = lambda tx_id, uid: (
+        sell if tx_id == sell.id else buy if tx_id == buy.id else None
+    )
+    mock_link_repository.get_allocated_for_buy_excluding_sell.return_value = Decimal("0")
+    link = TransactionLink(
+        id=uuid.uuid4(),
+        sell_id=sell.id,
+        buy_id=buy.id,
+        quantity=Decimal("10"),
+        created_at=sell.created_at,
+    )
+    mock_link_repository.replace_links_for_sell.return_value = [link]
+
+    response = await async_client.put(
+        f"/api/transactions/{sell.id}/links",
+        json={"links": [[str(buy.id), "10"]]},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["realized_pnl"] == "200"
+    assert len(data["links"]) == 1
+
+
+async def test_update_sell_links_returns_422_on_invalid(
+    async_client: Any,
+    mock_transaction_repository: AsyncMock,
+) -> None:
+    buy = make_transaction(
+        type=TransactionType.BUY,
+        quantity=Decimal("10"),
+        price_per_unit=Decimal("100"),
+        currency="EUR",
+    )
+    sell = make_transaction(
+        type=TransactionType.SELL,
+        quantity=Decimal("10"),
+        price_per_unit=Decimal("120"),
+        currency="USD",
+    )
+    mock_transaction_repository.get_by_id.side_effect = lambda tx_id, uid: (
+        sell if tx_id == sell.id else buy if tx_id == buy.id else None
+    )
+
+    response = await async_client.put(
+        f"/api/transactions/{sell.id}/links",
+        json={"links": [[str(buy.id), "10"]]},
+    )
+    assert response.status_code == 422
+
+
+async def test_get_available_buys(
+    async_client: Any,
+    mock_transaction_repository: AsyncMock,
+) -> None:
+    buy = make_transaction(
+        type=TransactionType.BUY, quantity=Decimal("10"), price_per_unit=Decimal("100")
+    )
+    sell = make_transaction(
+        type=TransactionType.SELL, quantity=Decimal("5"), price_per_unit=Decimal("120")
+    )
+    mock_transaction_repository.get_by_id.return_value = sell
+    mock_transaction_repository.list_open_buys.return_value = [(buy, Decimal("10"))]
+    mock_transaction_repository.get_links_by_sell.return_value = []
+    mock_transaction_repository.list_by_ids.return_value = []
+
+    response = await async_client.get(f"/api/transactions/{sell.id}/available-buys")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["sell"]["id"] == str(sell.id)
+    assert len(data["available_buys"]) == 1
+    assert data["available_buys"][0]["qty_available"] == "10"
 
 
 async def test_create_asset_returns_existing_on_ticker_dupe(

--- a/backend/abacus/tests/unit/test_pnl.py
+++ b/backend/abacus/tests/unit/test_pnl.py
@@ -1,0 +1,118 @@
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from abacus.application.services.pnl import compute_pnl
+from abacus.domain.models.transaction import TransactionType
+from abacus.domain.models.transaction_link import TransactionLink
+from tests.conftest import make_transaction
+
+_NOW = datetime.now(tz=UTC)
+BUY = TransactionType.BUY
+SELL = TransactionType.SELL
+D = Decimal
+
+
+def make_link(sell_id: uuid.UUID, buy_id: uuid.UUID, quantity: str) -> TransactionLink:
+    return TransactionLink(
+        id=uuid.uuid4(),
+        sell_id=sell_id,
+        buy_id=buy_id,
+        quantity=D(quantity),
+        created_at=_NOW,
+    )
+
+
+def test_compute_pnl_simple_no_fees() -> None:
+    """Buy 10@100, sell 10@120 → pnl=200, cost_basis=1000, pct=20%."""
+    buy = make_transaction(type=BUY, quantity=D("10"), price_per_unit=D("100"), fee=D("0"))
+    sell = make_transaction(type=SELL, quantity=D("10"), price_per_unit=D("120"), fee=D("0"))
+    link = make_link(sell.id, buy.id, "10")
+
+    result = compute_pnl(sell, [link], {buy.id: buy})
+
+    assert result.pnl == D("200")
+    assert result.cost_basis == D("1000")
+    assert result.pnl_pct == D("20")
+    assert result.unlinked_quantity == D("0")
+
+
+def test_compute_pnl_with_fees_reduces_profit() -> None:
+    """Buy 10@100 fee=5, sell 10@120 fee=5 → pnl=200-5-5=190."""
+    buy = make_transaction(type=BUY, quantity=D("10"), price_per_unit=D("100"), fee=D("5"))
+    sell = make_transaction(type=SELL, quantity=D("10"), price_per_unit=D("120"), fee=D("5"))
+    link = make_link(sell.id, buy.id, "10")
+
+    result = compute_pnl(sell, [link], {buy.id: buy})
+
+    assert result.pnl == D("190")
+    assert result.cost_basis == D("1005")
+    assert result.unlinked_quantity == D("0")
+
+
+def test_compute_pnl_loss() -> None:
+    """Buy 10@100, sell 10@80 → pnl=-200."""
+    buy = make_transaction(type=BUY, quantity=D("10"), price_per_unit=D("100"), fee=D("0"))
+    sell = make_transaction(type=SELL, quantity=D("10"), price_per_unit=D("80"), fee=D("0"))
+    link = make_link(sell.id, buy.id, "10")
+
+    result = compute_pnl(sell, [link], {buy.id: buy})
+
+    assert result.pnl == D("-200")
+    assert result.pnl_pct == D("-20")
+
+
+def test_compute_pnl_partial_sell_unlinked() -> None:
+    """Sell 10 but only 6 linked → unlinked=4, pnl only from linked qty."""
+    buy = make_transaction(type=BUY, quantity=D("10"), price_per_unit=D("100"), fee=D("0"))
+    sell = make_transaction(type=SELL, quantity=D("10"), price_per_unit=D("120"), fee=D("0"))
+    link = make_link(sell.id, buy.id, "6")
+
+    result = compute_pnl(sell, [link], {buy.id: buy})
+
+    assert result.unlinked_quantity == D("4")
+    assert result.pnl == D("120")  # 6*(120-100)
+    assert result.cost_basis == D("600")
+
+
+def test_compute_pnl_multi_buy_fifo() -> None:
+    """Buy 10@100 + 5@160, sell 12 linked to both buys."""
+    buy1 = make_transaction(type=BUY, quantity=D("10"), price_per_unit=D("100"), fee=D("0"))
+    buy2 = make_transaction(type=BUY, quantity=D("5"), price_per_unit=D("160"), fee=D("0"))
+    sell = make_transaction(type=SELL, quantity=D("12"), price_per_unit=D("150"), fee=D("0"))
+    link1 = make_link(sell.id, buy1.id, "10")
+    link2 = make_link(sell.id, buy2.id, "2")
+
+    result = compute_pnl(sell, [link1, link2], {buy1.id: buy1, buy2.id: buy2})
+
+    # sell proceeds: 12*150 = 1800
+    # buy cost: 10*100 + 2*160 = 1000 + 320 = 1320
+    assert result.pnl == D("480")
+    assert result.cost_basis == D("1320")
+    assert result.unlinked_quantity == D("0")
+
+
+def test_compute_pnl_fee_prorated_on_partial_buy() -> None:
+    """Buy 10@100 fee=10 (1/unit), link 5 only → buy fee allocated = 5."""
+    buy = make_transaction(type=BUY, quantity=D("10"), price_per_unit=D("100"), fee=D("10"))
+    sell = make_transaction(type=SELL, quantity=D("5"), price_per_unit=D("110"), fee=D("0"))
+    link = make_link(sell.id, buy.id, "5")
+
+    result = compute_pnl(sell, [link], {buy.id: buy})
+
+    # buy_cost_alloc = 5*100 + 10*(5/10) = 500 + 5 = 505
+    # sell_proceeds = 5*110 = 550, pnl = 45
+    assert result.pnl == D("45")
+    assert result.cost_basis == D("505")
+
+
+def test_compute_pnl_no_links_all_unlinked() -> None:
+    """No links → pnl=0, cost_basis=0, pct=None, unlinked=sell.qty."""
+    sell = make_transaction(type=SELL, quantity=D("10"), price_per_unit=D("120"), fee=D("0"))
+
+    result = compute_pnl(sell, [], {})
+
+    assert result.pnl == D("0")
+    assert result.cost_basis == D("0")
+    assert result.pnl_pct is None
+    assert result.unlinked_quantity == D("10")

--- a/backend/abacus/tests/unit/test_transaction_service.py
+++ b/backend/abacus/tests/unit/test_transaction_service.py
@@ -1,22 +1,44 @@
 import uuid
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock
 
 import pytest
 
 from abacus.application.services.transaction_service import TransactionService
-from abacus.domain.exceptions import NotFoundError
+from abacus.domain.exceptions import LinkValidationError, NotFoundError
 from abacus.domain.models.transaction import TransactionType
+from abacus.domain.models.transaction_link import TransactionLink
 from tests.conftest import TEST_ASSET_ID, TEST_USER_ID, make_asset, make_transaction
+
+_NOW = datetime.now(tz=UTC)
+
+
+def make_link(sell_id: uuid.UUID, buy_id: uuid.UUID, quantity: str) -> TransactionLink:
+    return TransactionLink(
+        id=uuid.uuid4(),
+        sell_id=sell_id,
+        buy_id=buy_id,
+        quantity=Decimal(quantity),
+        created_at=_NOW,
+    )
+
+
+@pytest.fixture
+def mock_link_repository() -> AsyncMock:
+    return AsyncMock()
 
 
 @pytest.fixture
 def service(
-    mock_asset_repository: AsyncMock, mock_transaction_repository: AsyncMock
+    mock_asset_repository: AsyncMock,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
 ) -> TransactionService:
     return TransactionService(
         asset_repository=mock_asset_repository,
         transaction_repository=mock_transaction_repository,
+        link_repository=mock_link_repository,
     )
 
 
@@ -101,3 +123,257 @@ async def test_list_transactions_returns_paginated(
 
     assert items == txs
     assert total == 2
+
+
+# ── FIFO auto-linking tests ───────────────────────────────────────────────────
+
+
+async def test_create_sell_auto_links_fifo(
+    service: TransactionService,
+    mock_asset_repository: AsyncMock,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    """Creating a sell with 12 units should consume 10 from buy1 then 2 from buy2 (FIFO)."""
+    buy1 = make_transaction(type=TransactionType.BUY, quantity=Decimal("10"), date=date(2024, 1, 1))
+    buy2 = make_transaction(type=TransactionType.BUY, quantity=Decimal("5"), date=date(2024, 2, 1))
+    sell = make_transaction(type=TransactionType.SELL, quantity=Decimal("12"))
+    asset = make_asset()
+
+    mock_asset_repository.get_by_id.return_value = asset
+    mock_transaction_repository.create.return_value = sell
+    mock_transaction_repository.list_open_buys.return_value = [
+        (buy1, Decimal("10")),
+        (buy2, Decimal("5")),
+    ]
+    mock_link_repository.replace_links_for_sell.return_value = []
+
+    await service.create_transaction(
+        TEST_USER_ID,
+        {
+            "asset_id": TEST_ASSET_ID,
+            "date": sell.date,
+            "type": TransactionType.SELL,
+            "quantity": Decimal("12"),
+            "price_per_unit": Decimal("120"),
+            "fee": Decimal("0"),
+            "currency": "USD",
+        },
+    )
+
+    mock_link_repository.replace_links_for_sell.assert_called_once()
+    call_sell_id, call_links = mock_link_repository.replace_links_for_sell.call_args[0]
+    assert call_sell_id == sell.id
+    assert call_links == [(buy1.id, Decimal("10")), (buy2.id, Decimal("2"))]
+
+
+async def test_create_sell_partial_when_insufficient_buys(
+    service: TransactionService,
+    mock_asset_repository: AsyncMock,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    """When buys cover only part of sell qty, link partially and don't raise."""
+    buy = make_transaction(type=TransactionType.BUY, quantity=Decimal("5"), date=date(2024, 1, 1))
+    sell = make_transaction(type=TransactionType.SELL, quantity=Decimal("10"))
+    asset = make_asset()
+
+    mock_asset_repository.get_by_id.return_value = asset
+    mock_transaction_repository.create.return_value = sell
+    mock_transaction_repository.list_open_buys.return_value = [(buy, Decimal("5"))]
+    mock_link_repository.replace_links_for_sell.return_value = []
+
+    await service.create_transaction(
+        TEST_USER_ID,
+        {
+            "asset_id": TEST_ASSET_ID,
+            "date": sell.date,
+            "type": TransactionType.SELL,
+            "quantity": Decimal("10"),
+            "price_per_unit": Decimal("120"),
+            "fee": Decimal("0"),
+            "currency": "USD",
+        },
+    )
+
+    _, call_links = mock_link_repository.replace_links_for_sell.call_args[0]
+    assert call_links == [(buy.id, Decimal("5"))]
+
+
+async def test_create_buy_does_not_trigger_fifo(
+    service: TransactionService,
+    mock_asset_repository: AsyncMock,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    """BUY transactions never call replace_links_for_sell."""
+    asset = make_asset()
+    tx = make_transaction(type=TransactionType.BUY)
+    mock_asset_repository.get_by_id.return_value = asset
+    mock_transaction_repository.create.return_value = tx
+
+    await service.create_transaction(
+        TEST_USER_ID,
+        {
+            "asset_id": TEST_ASSET_ID,
+            "date": tx.date,
+            "type": TransactionType.BUY,
+            "quantity": Decimal("10"),
+            "price_per_unit": Decimal("100"),
+            "fee": Decimal("0"),
+            "currency": "USD",
+        },
+    )
+
+    mock_link_repository.replace_links_for_sell.assert_not_called()
+
+
+# ── update_sell_links validation tests ───────────────────────────────────────
+
+
+async def _setup_update_sell_links(
+    mock_tx_repo: AsyncMock,
+    mock_link_repo: AsyncMock,
+    sell: object,
+    buys: list,
+    buy_allocations: dict | None = None,
+) -> None:
+    mock_tx_repo.get_by_id.side_effect = lambda tx_id, user_id: next(
+        (t for t in [sell, *buys] if t.id == tx_id), None
+    )
+    mock_link_repo.get_allocated_for_buy_excluding_sell.return_value = Decimal("0")
+    if buy_allocations:
+        mock_link_repo.get_allocated_for_buy_excluding_sell.side_effect = lambda buy_id, sell_id: (
+            buy_allocations.get(buy_id, Decimal("0"))
+        )
+    mock_link_repo.replace_links_for_sell.return_value = []
+
+
+def _tx_side_effect(*txs: object) -> object:
+    def _lookup(tx_id: uuid.UUID, uid: uuid.UUID) -> object:
+        return next((t for t in txs if t.id == tx_id), None)  # type: ignore[attr-defined]
+
+    return _lookup
+
+
+async def test_update_sell_links_success(
+    service: TransactionService,
+    mock_asset_repository: AsyncMock,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    buy = make_transaction(
+        type=TransactionType.BUY, quantity=Decimal("10"), date=date(2024, 1, 1), fee=Decimal("0")
+    )
+    sell = make_transaction(
+        type=TransactionType.SELL, quantity=Decimal("5"), date=date(2024, 6, 1), fee=Decimal("0")
+    )
+
+    await _setup_update_sell_links(mock_transaction_repository, mock_link_repository, sell, [buy])
+
+    result = await service.update_sell_links(TEST_USER_ID, sell.id, [(buy.id, Decimal("5"))])
+
+    mock_link_repository.replace_links_for_sell.assert_called_once_with(
+        sell.id, [(buy.id, Decimal("5"))]
+    )
+    assert result is not None
+
+
+async def test_update_sell_links_raises_if_sell_not_found(
+    service: TransactionService,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    mock_transaction_repository.get_by_id.return_value = None
+    with pytest.raises(NotFoundError):
+        await service.update_sell_links(TEST_USER_ID, uuid.uuid4(), [])
+
+
+async def test_update_sell_links_raises_if_buy_not_found(
+    service: TransactionService,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    sell = make_transaction(type=TransactionType.SELL, quantity=Decimal("5"), date=date(2024, 6, 1))
+    mock_transaction_repository.get_by_id.side_effect = _tx_side_effect(sell)
+    with pytest.raises(NotFoundError):
+        await service.update_sell_links(TEST_USER_ID, sell.id, [(uuid.uuid4(), Decimal("5"))])
+
+
+async def test_update_sell_links_rejects_currency_mismatch(
+    service: TransactionService,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    buy = make_transaction(
+        type=TransactionType.BUY, quantity=Decimal("10"), currency="EUR", date=date(2024, 1, 1)
+    )
+    sell = make_transaction(
+        type=TransactionType.SELL, quantity=Decimal("5"), currency="USD", date=date(2024, 6, 1)
+    )
+    mock_transaction_repository.get_by_id.side_effect = _tx_side_effect(sell, buy)
+    with pytest.raises(LinkValidationError, match="currency"):
+        await service.update_sell_links(TEST_USER_ID, sell.id, [(buy.id, Decimal("5"))])
+
+
+async def test_update_sell_links_rejects_different_asset(
+    service: TransactionService,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    other_asset_id = uuid.uuid4()
+    buy = make_transaction(
+        type=TransactionType.BUY,
+        asset_id=other_asset_id,
+        quantity=Decimal("10"),
+        date=date(2024, 1, 1),
+    )
+    sell = make_transaction(
+        type=TransactionType.SELL,
+        asset_id=TEST_ASSET_ID,
+        quantity=Decimal("5"),
+        date=date(2024, 6, 1),
+    )
+    mock_transaction_repository.get_by_id.side_effect = _tx_side_effect(sell, buy)
+    with pytest.raises(LinkValidationError, match="asset"):
+        await service.update_sell_links(TEST_USER_ID, sell.id, [(buy.id, Decimal("5"))])
+
+
+async def test_update_sell_links_rejects_buy_after_sell_date(
+    service: TransactionService,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    buy = make_transaction(type=TransactionType.BUY, quantity=Decimal("10"), date=date(2024, 12, 1))
+    sell = make_transaction(type=TransactionType.SELL, quantity=Decimal("5"), date=date(2024, 6, 1))
+    mock_transaction_repository.get_by_id.side_effect = _tx_side_effect(sell, buy)
+    with pytest.raises(LinkValidationError, match="date"):
+        await service.update_sell_links(TEST_USER_ID, sell.id, [(buy.id, Decimal("5"))])
+
+
+async def test_update_sell_links_rejects_overallocation_of_sell(
+    service: TransactionService,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    """Link quantities exceed sell.quantity."""
+    buy = make_transaction(type=TransactionType.BUY, quantity=Decimal("20"), date=date(2024, 1, 1))
+    sell = make_transaction(type=TransactionType.SELL, quantity=Decimal("5"), date=date(2024, 6, 1))
+    mock_transaction_repository.get_by_id.side_effect = _tx_side_effect(sell, buy)
+    mock_link_repository.get_allocated_for_buy_excluding_sell.return_value = Decimal("0")
+    with pytest.raises(LinkValidationError, match="quantity"):
+        await service.update_sell_links(TEST_USER_ID, sell.id, [(buy.id, Decimal("10"))])
+
+
+async def test_update_sell_links_rejects_overallocation_of_buy(
+    service: TransactionService,
+    mock_transaction_repository: AsyncMock,
+    mock_link_repository: AsyncMock,
+) -> None:
+    """Other sells have already consumed 8 of this buy's 10 units, new link wants 5 more."""
+    buy = make_transaction(type=TransactionType.BUY, quantity=Decimal("10"), date=date(2024, 1, 1))
+    sell = make_transaction(type=TransactionType.SELL, quantity=Decimal("5"), date=date(2024, 6, 1))
+    mock_transaction_repository.get_by_id.side_effect = _tx_side_effect(sell, buy)
+    mock_link_repository.get_allocated_for_buy_excluding_sell.return_value = Decimal("8")
+    with pytest.raises(LinkValidationError, match="overallocated"):
+        await service.update_sell_links(TEST_USER_ID, sell.id, [(buy.id, Decimal("5"))])

--- a/frontend/abacus/.claude/plans/isse-20-link-transactions.md
+++ b/frontend/abacus/.claude/plans/isse-20-link-transactions.md
@@ -1,0 +1,23 @@
+# Plan — Issue #20: Realized P&L con linking buy↔sell en abacus
+
+## Status: COMPLETADO ✓
+
+## Pasos
+
+- [x] Modelo de dominio: `TransactionLink`, `LinkValidationError`, puertos extendidos
+- [x] Migración alembic: `c1d2e3f4a5b6_add_transaction_links.py` (`down_revision='b3c4d5e6f7a8'`)
+- [x] Repositorios: `sqlalchemy_transaction_link_repository.py` + métodos nuevos en `sqlalchemy_transaction_repository.py` (`list_open_buys`, `get_by_id`, `get_links_*`, `list_by_ids`)
+- [x] Servicio: `pnl.py` (función pura), `transaction_service.py` (`_auto_link_fifo`, `update_sell_links`, `get_available_buys_for_sell`, `compute_summary_by_asset`)
+- [x] API: 4 nuevos endpoints (`GET /summary/by-asset`, `GET /{id}/available-buys`, `PUT /{id}/links`, enriquecimiento del `GET /`)
+- [x] Schemas: `TransactionLinkOut`, `LinksUpdateRequest`, `AvailableBuyOut`, `AvailableBuysResponse`, `AssetPnLSummary`
+- [x] Frontend tipos: `Transaction` extendido, `TransactionLink`, `AvailableBuy`, `AvailableBuysResponse`, `AssetPnLSummary`
+- [x] Frontend API: `updateSellLinks`, `getAvailableBuys`, `getSummaryByAsset`
+- [x] Frontend hooks: `updateLinks` en `useTransactions`, nuevo `useAssetSummary`
+- [x] Frontend componentes: `LinksModal`, `AssetSummary`, `TransactionList` actualizado, `Dashboard` actualizado
+- [x] Tests backend: `test_pnl.py` (7 casos), `test_transaction_service.py` (+12 tests), `test_api.py` (+4 e2e) — 54 passed
+- [x] Tests frontend: `LinksModal.test.tsx`, `TransactionList.test.tsx`, `AssetSummary.test.tsx` — 20 passed
+- [x] Lint/typecheck backend: ruff + mypy — clean
+- [x] Lint/typecheck frontend: eslint + tsc — clean
+- [x] Smoke test local: cálculo verificado manualmente con ICFI (−34,50 €, −11,18%) ✓
+- [x] CI checks: todos verdes en PR #21
+- [x] Fixes runtime: `row.TransactionModel.quantity` en `list_open_buys`, fee restado en venta en `TransactionList.tsx`

--- a/frontend/abacus/src/api/transactions.ts
+++ b/frontend/abacus/src/api/transactions.ts
@@ -1,10 +1,31 @@
 import { request } from './client'
-import type { PaginatedTransactions, TransactionCreate } from '../types/models'
+import type {
+  AvailableBuysResponse,
+  AssetPnLSummary,
+  PaginatedTransactions,
+  Transaction,
+  TransactionCreate,
+} from '../types/models'
 
 export function listTransactions(limit = 50, offset = 0): Promise<PaginatedTransactions> {
   return request<PaginatedTransactions>('GET', `/transactions/?limit=${limit}&offset=${offset}`)
 }
 
-export function createTransaction(data: TransactionCreate): Promise<PaginatedTransactions['items'][0]> {
+export function createTransaction(data: TransactionCreate): Promise<Transaction> {
   return request('POST', '/transactions/', data)
+}
+
+export function updateSellLinks(
+  sellId: string,
+  links: [string, string][],
+): Promise<Transaction> {
+  return request('PUT', `/transactions/${sellId}/links`, { links })
+}
+
+export function getAvailableBuys(sellId: string): Promise<AvailableBuysResponse> {
+  return request('GET', `/transactions/${sellId}/available-buys`)
+}
+
+export function getSummaryByAsset(): Promise<AssetPnLSummary[]> {
+  return request('GET', '/transactions/summary/by-asset')
 }

--- a/frontend/abacus/src/components/AssetSummary.test.tsx
+++ b/frontend/abacus/src/components/AssetSummary.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import AssetSummary from './AssetSummary'
+import type { AssetPnLSummary } from '../types/models'
+
+const SUMMARIES: AssetPnLSummary[] = [
+  {
+    asset_id: 'a1',
+    asset_ticker: 'AAPL',
+    asset_name: 'Apple Inc.',
+    currency: 'USD',
+    realized_pnl: '150.00',
+    realized_pnl_pct: '10.00',
+    cost_basis: '1500.00',
+    sells_count: 2,
+  },
+  {
+    asset_id: 'a2',
+    asset_ticker: null,
+    asset_name: 'Bitcoin',
+    currency: 'EUR',
+    realized_pnl: '-50.00',
+    realized_pnl_pct: '-5.00',
+    cost_basis: '1000.00',
+    sells_count: 1,
+  },
+]
+
+describe('AssetSummary', () => {
+  it('renders nothing while loading', () => {
+    const { container } = render(<AssetSummary summaries={[]} loading={true} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when no summaries', () => {
+    const { container } = render(<AssetSummary summaries={[]} loading={false} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders asset rows', () => {
+    render(<AssetSummary summaries={SUMMARIES} loading={false} />)
+    expect(screen.getByText('AAPL')).toBeInTheDocument()
+    expect(screen.getByText('Apple Inc.')).toBeInTheDocument()
+    expect(screen.getByText('Bitcoin')).toBeInTheDocument()
+  })
+
+  it('shows positive P&L with green badge', () => {
+    render(<AssetSummary summaries={[SUMMARIES[0]]} loading={false} />)
+    const badge = screen.getAllByText(/\+/)[0]
+    expect(badge).toBeInTheDocument()
+  })
+
+  it('shows sells count and cost basis', () => {
+    render(<AssetSummary summaries={SUMMARIES} loading={false} />)
+    expect(screen.getByText(/2 ventas/)).toBeInTheDocument()
+    expect(screen.getByText(/1 venta[^s]/)).toBeInTheDocument()
+  })
+})

--- a/frontend/abacus/src/components/AssetSummary.tsx
+++ b/frontend/abacus/src/components/AssetSummary.tsx
@@ -1,0 +1,69 @@
+import type { AssetPnLSummary } from '../types/models'
+import { formatCurrency } from '../utils/format'
+
+interface Props {
+  summaries: AssetPnLSummary[]
+  loading: boolean
+}
+
+function PnlBadge({ pnl, pct, currency }: { pnl: string; pct: string | null; currency: string }) {
+  const value = Number(pnl)
+  const isPositive = value >= 0
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded ${
+        isPositive ? 'bg-green-900/40 text-green-400' : 'bg-red-900/40 text-red-400'
+      }`}
+    >
+      {isPositive ? '+' : ''}
+      {formatCurrency(pnl, currency)}
+      {pct !== null && (
+        <span className="opacity-75">
+          ({isPositive ? '+' : ''}
+          {Number(pct).toFixed(2)}%)
+        </span>
+      )}
+    </span>
+  )
+}
+
+export default function AssetSummary({ summaries, loading }: Props) {
+  if (loading || summaries.length === 0) return null
+
+  const totalPnl = summaries.reduce((s, a) => s + Number(a.realized_pnl), 0)
+  const totalCost = summaries.reduce((s, a) => s + Number(a.cost_basis), 0)
+  const totalPct = totalCost > 0 ? (totalPnl / totalCost) * 100 : null
+
+  return (
+    <div className="bg-slate-800 rounded-2xl overflow-hidden">
+      <div className="px-6 py-4 border-b border-slate-700 flex items-center justify-between">
+        <h2 className="text-base font-semibold text-white">Rentabilidad realizada</h2>
+        <PnlBadge
+          pnl={String(totalPnl.toFixed(8))}
+          pct={totalPct !== null ? String(totalPct.toFixed(2)) : null}
+          currency={summaries[0]?.currency ?? 'EUR'}
+        />
+      </div>
+
+      <div className="divide-y divide-slate-700">
+        {summaries.map(s => (
+          <div key={s.asset_id} className="px-6 py-3 flex items-center justify-between gap-4">
+            <div>
+              <p className="text-sm font-medium text-white">
+                {s.asset_ticker ?? s.asset_name}
+                {s.asset_ticker && (
+                  <span className="ml-1.5 text-xs text-slate-400 font-normal">{s.asset_name}</span>
+                )}
+              </p>
+              <p className="text-xs text-slate-500">
+                {s.sells_count} venta{s.sells_count !== 1 ? 's' : ''} · coste{' '}
+                {formatCurrency(s.cost_basis, s.currency)}
+              </p>
+            </div>
+            <PnlBadge pnl={s.realized_pnl} pct={s.realized_pnl_pct} currency={s.currency} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/abacus/src/components/Dashboard.tsx
+++ b/frontend/abacus/src/components/Dashboard.tsx
@@ -1,14 +1,29 @@
+import { useState } from 'react'
 import { useAuth } from '../auth/AuthContext'
 import { useAssets } from '../hooks/useAssets'
+import { useAssetSummary } from '../hooks/useAssetSummary'
 import { useTransactions } from '../hooks/useTransactions'
+import AssetSummary from './AssetSummary'
 import TransactionForm from './TransactionForm'
 import TransactionList from './TransactionList'
 
 export default function Dashboard() {
   const { logout } = useAuth()
   const { assets, loading: assetsLoading, addAsset } = useAssets()
-  const { transactions, total, loading: txLoading, hasMore, addTransaction, loadMore } =
+  const [summaryKey, setSummaryKey] = useState(0)
+  const { summaries, loading: summaryLoading } = useAssetSummary(summaryKey)
+  const { transactions, total, loading: txLoading, hasMore, addTransaction, updateLinks, loadMore } =
     useTransactions()
+
+  const handleAddTransaction = async (data: Parameters<typeof addTransaction>[0]) => {
+    await addTransaction(data)
+    setSummaryKey(k => k + 1)
+  }
+
+  const handleUpdateLinks = async (sellId: string, links: [string, string][]) => {
+    await updateLinks(sellId, links)
+    setSummaryKey(k => k + 1)
+  }
 
   return (
     <div className="min-h-screen bg-slate-900">
@@ -33,10 +48,12 @@ export default function Dashboard() {
         ) : (
           <TransactionForm
             assets={assets}
-            onSubmit={addTransaction}
+            onSubmit={handleAddTransaction}
             onAddAsset={addAsset}
           />
         )}
+
+        <AssetSummary summaries={summaries} loading={summaryLoading} />
 
         <TransactionList
           transactions={transactions}
@@ -45,6 +62,7 @@ export default function Dashboard() {
           hasMore={hasMore}
           loading={txLoading}
           onLoadMore={loadMore}
+          onUpdateLinks={handleUpdateLinks}
         />
       </main>
     </div>

--- a/frontend/abacus/src/components/LinksModal.test.tsx
+++ b/frontend/abacus/src/components/LinksModal.test.tsx
@@ -21,6 +21,29 @@ const SELL: Transaction = {
   currency: 'USD',
   date: '2024-06-01',
   broker: null,
+  notes: null,
+  created_at: '2024-06-01T00:00:00Z',
+  updated_at: '2024-06-01T00:00:00Z',
+  realized_pnl: null,
+  realized_pnl_pct: null,
+  cost_basis: null,
+  unlinked_quantity: null,
+  links: [],
+}
+
+const BUY_TX: Transaction = {
+  id: 'buy1',
+  asset_id: 'a1',
+  type: 'buy',
+  quantity: '10',
+  price_per_unit: '150',
+  fee: '1',
+  currency: 'USD',
+  date: '2024-01-01',
+  broker: null,
+  notes: null,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
   realized_pnl: null,
   realized_pnl_pct: null,
   cost_basis: null,
@@ -29,22 +52,7 @@ const SELL: Transaction = {
 }
 
 const BUY_ENTRY = {
-  buy: {
-    id: 'buy1',
-    asset_id: 'a1',
-    type: 'buy' as const,
-    quantity: '10',
-    price_per_unit: '150',
-    fee: '1',
-    currency: 'USD',
-    date: '2024-01-01',
-    broker: null,
-    realized_pnl: null,
-    realized_pnl_pct: null,
-    cost_basis: null,
-    unlinked_quantity: null,
-    links: [],
-  },
+  buy: BUY_TX,
   qty_available: '10',
   qty_linked: '0',
 }
@@ -55,7 +63,7 @@ describe('LinksModal', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetAvailableBuys.mockResolvedValue({ available_buys: [BUY_ENTRY] })
+    mockGetAvailableBuys.mockResolvedValue({ sell: SELL, available_buys: [BUY_ENTRY] })
   })
 
   it('renders header with sell info', () => {
@@ -71,7 +79,7 @@ describe('LinksModal', () => {
   })
 
   it('shows empty state when no buys available', async () => {
-    mockGetAvailableBuys.mockResolvedValue({ available_buys: [] })
+    mockGetAvailableBuys.mockResolvedValue({ sell: SELL, available_buys: [] })
     render(<LinksModal sell={SELL} onSave={onSave} onClose={onClose} />)
     await waitFor(() => {
       expect(screen.getByText(/No hay compras disponibles/)).toBeInTheDocument()

--- a/frontend/abacus/src/components/LinksModal.test.tsx
+++ b/frontend/abacus/src/components/LinksModal.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import LinksModal from './LinksModal'
+import type { Transaction } from '../types/models'
+
+vi.mock('../api/transactions', () => ({
+  getAvailableBuys: vi.fn(),
+}))
+
+import { getAvailableBuys } from '../api/transactions'
+const mockGetAvailableBuys = vi.mocked(getAvailableBuys)
+
+const SELL: Transaction = {
+  id: 'sell1',
+  asset_id: 'a1',
+  type: 'sell',
+  quantity: '10',
+  price_per_unit: '180',
+  fee: '1',
+  currency: 'USD',
+  date: '2024-06-01',
+  broker: null,
+  realized_pnl: null,
+  realized_pnl_pct: null,
+  cost_basis: null,
+  unlinked_quantity: null,
+  links: [],
+}
+
+const BUY_ENTRY = {
+  buy: {
+    id: 'buy1',
+    asset_id: 'a1',
+    type: 'buy' as const,
+    quantity: '10',
+    price_per_unit: '150',
+    fee: '1',
+    currency: 'USD',
+    date: '2024-01-01',
+    broker: null,
+    realized_pnl: null,
+    realized_pnl_pct: null,
+    cost_basis: null,
+    unlinked_quantity: null,
+    links: [],
+  },
+  qty_available: '10',
+  qty_linked: '0',
+}
+
+describe('LinksModal', () => {
+  const onSave = vi.fn().mockResolvedValue(undefined)
+  const onClose = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAvailableBuys.mockResolvedValue({ available_buys: [BUY_ENTRY] })
+  })
+
+  it('renders header with sell info', () => {
+    render(<LinksModal sell={SELL} onSave={onSave} onClose={onClose} />)
+    expect(screen.getByText('Editar enlaces')).toBeInTheDocument()
+  })
+
+  it('loads and shows available buys', async () => {
+    render(<LinksModal sell={SELL} onSave={onSave} onClose={onClose} />)
+    await waitFor(() => {
+      expect(screen.getByText('1/1/2024')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no buys available', async () => {
+    mockGetAvailableBuys.mockResolvedValue({ available_buys: [] })
+    render(<LinksModal sell={SELL} onSave={onSave} onClose={onClose} />)
+    await waitFor(() => {
+      expect(screen.getByText(/No hay compras disponibles/)).toBeInTheDocument()
+    })
+  })
+
+  it('calls onSave with correct links on submit', async () => {
+    render(<LinksModal sell={SELL} onSave={onSave} onClose={onClose} />)
+    await waitFor(() => screen.getByText('1/1/2024'))
+
+    const input = screen.getByPlaceholderText('0')
+    await userEvent.clear(input)
+    await userEvent.type(input, '5')
+
+    await userEvent.click(screen.getByText('Guardar'))
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith('sell1', [['buy1', '5']])
+    })
+  })
+
+  it('shows error when total quantity exceeds sell quantity', async () => {
+    render(<LinksModal sell={SELL} onSave={onSave} onClose={onClose} />)
+    await waitFor(() => screen.getByText('1/1/2024'))
+
+    const input = screen.getByPlaceholderText('0')
+    await userEvent.clear(input)
+    await userEvent.type(input, '99')
+
+    await userEvent.click(screen.getByText('Guardar'))
+    await waitFor(() => {
+      expect(screen.getByText(/supera la venta/)).toBeInTheDocument()
+    })
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('calls onClose when cancel is clicked', async () => {
+    render(<LinksModal sell={SELL} onSave={onSave} onClose={onClose} />)
+    await userEvent.click(screen.getByText('Cancelar'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/abacus/src/components/LinksModal.tsx
+++ b/frontend/abacus/src/components/LinksModal.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useState } from 'react'
+import { getAvailableBuys } from '../api/transactions'
+import type { AvailableBuy, Transaction } from '../types/models'
+import { formatDate, formatCurrency, formatQuantity } from '../utils/format'
+
+interface Props {
+  sell: Transaction
+  onSave: (sellId: string, links: [string, string][]) => Promise<void>
+  onClose: () => void
+}
+
+export default function LinksModal({ sell, onSave, onClose }: Props) {
+  const [availableBuys, setAvailableBuys] = useState<AvailableBuy[]>([])
+  const [quantities, setQuantities] = useState<Record<string, string>>({})
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    getAvailableBuys(sell.id)
+      .then(({ available_buys }) => {
+        setAvailableBuys(available_buys)
+        const initial: Record<string, string> = {}
+        for (const { buy, qty_linked } of available_buys) {
+          initial[buy.id] = Number(qty_linked) > 0 ? qty_linked : ''
+        }
+        setQuantities(initial)
+      })
+      .catch(() => setError('Error cargando compras disponibles'))
+      .finally(() => setLoading(false))
+  }, [sell.id])
+
+  const handleSave = async () => {
+    const links: [string, string][] = Object.entries(quantities)
+      .filter(([, qty]) => qty && Number(qty) > 0)
+      .map(([buyId, qty]) => [buyId, qty])
+
+    const totalLinked = links.reduce((s, [, q]) => s + Number(q), 0)
+    if (totalLinked > Number(sell.quantity)) {
+      setError(`La cantidad total (${totalLinked}) supera la venta (${sell.quantity})`)
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+    try {
+      await onSave(sell.id, links)
+      onClose()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Error guardando enlaces')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="bg-slate-800 rounded-2xl w-full max-w-lg mx-4 overflow-hidden shadow-2xl">
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-slate-700 flex items-center justify-between">
+          <div>
+            <h2 className="text-base font-semibold text-white">Editar enlaces</h2>
+            <p className="text-xs text-slate-400 mt-0.5">
+              Venta de {formatQuantity(sell.quantity)} el {formatDate(sell.date)} ·{' '}
+              {formatCurrency(sell.price_per_unit, sell.currency)}/u
+            </p>
+          </div>
+          <button onClick={onClose} className="text-slate-400 hover:text-white text-xl leading-none">
+            ×
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-4 max-h-80 overflow-y-auto">
+          {loading && (
+            <p className="text-sm text-slate-400 text-center py-4">Cargando compras…</p>
+          )}
+          {!loading && availableBuys.length === 0 && (
+            <p className="text-sm text-slate-400 text-center py-4">
+              No hay compras disponibles para este activo y divisa.
+            </p>
+          )}
+          {!loading && availableBuys.length > 0 && (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-xs text-slate-400 border-b border-slate-700">
+                  <th className="text-left pb-2">Compra</th>
+                  <th className="text-right pb-2">Disponible</th>
+                  <th className="text-right pb-2 w-28">Asignar</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-700/50">
+                {availableBuys.map(({ buy, qty_available }) => (
+                  <tr key={buy.id}>
+                    <td className="py-2.5">
+                      <p className="text-slate-200">{formatDate(buy.date)}</p>
+                      <p className="text-xs text-slate-400">
+                        {formatQuantity(buy.quantity)} × {formatCurrency(buy.price_per_unit, buy.currency)}
+                      </p>
+                    </td>
+                    <td className="py-2.5 text-right text-slate-300">
+                      {formatQuantity(qty_available)}
+                    </td>
+                    <td className="py-2.5 pl-3">
+                      <input
+                        type="number"
+                        min="0"
+                        max={qty_available}
+                        step="any"
+                        value={quantities[buy.id] ?? ''}
+                        onChange={e =>
+                          setQuantities(prev => ({ ...prev, [buy.id]: e.target.value }))
+                        }
+                        placeholder="0"
+                        className="w-full bg-slate-700 text-white text-right rounded-lg px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500"
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {error && (
+          <p className="px-6 py-2 text-xs text-red-400 bg-red-900/20">{error}</p>
+        )}
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-slate-700 flex justify-end gap-3">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-slate-400 hover:text-white transition-colors"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving || loading}
+            className="px-4 py-2 text-sm bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded-lg font-medium transition-colors"
+          >
+            {saving ? 'Guardando…' : 'Guardar'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/abacus/src/components/TransactionList.test.tsx
+++ b/frontend/abacus/src/components/TransactionList.test.tsx
@@ -8,7 +8,16 @@ vi.mock('../api/transactions', () => ({
   getAvailableBuys: vi.fn().mockResolvedValue({ available_buys: [] }),
 }))
 
-const ASSET: Asset = { id: 'a1', name: 'Apple Inc.', ticker: 'AAPL', currency: 'USD', asset_class: 'stock' }
+const ASSET: Asset = {
+  id: 'a1',
+  name: 'Apple Inc.',
+  ticker: 'AAPL',
+  isin: null,
+  currency: 'USD',
+  asset_class: 'stock',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
 
 const BUY_TX: Transaction = {
   id: 'tx1',
@@ -20,6 +29,9 @@ const BUY_TX: Transaction = {
   currency: 'USD',
   date: '2024-01-01',
   broker: null,
+  notes: null,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
   realized_pnl: null,
   realized_pnl_pct: null,
   cost_basis: null,
@@ -37,6 +49,9 @@ const SELL_TX: Transaction = {
   currency: 'USD',
   date: '2024-06-01',
   broker: null,
+  notes: null,
+  created_at: '2024-06-01T00:00:00Z',
+  updated_at: '2024-06-01T00:00:00Z',
   realized_pnl: '148.50',
   realized_pnl_pct: '20.33',
   cost_basis: '730.50',

--- a/frontend/abacus/src/components/TransactionList.test.tsx
+++ b/frontend/abacus/src/components/TransactionList.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import TransactionList from './TransactionList'
+import type { Asset, Transaction } from '../types/models'
+
+vi.mock('../api/transactions', () => ({
+  getAvailableBuys: vi.fn().mockResolvedValue({ available_buys: [] }),
+}))
+
+const ASSET: Asset = { id: 'a1', name: 'Apple Inc.', ticker: 'AAPL', currency: 'USD', asset_class: 'stock' }
+
+const BUY_TX: Transaction = {
+  id: 'tx1',
+  asset_id: 'a1',
+  type: 'buy',
+  quantity: '10',
+  price_per_unit: '150',
+  fee: '1',
+  currency: 'USD',
+  date: '2024-01-01',
+  broker: null,
+  realized_pnl: null,
+  realized_pnl_pct: null,
+  cost_basis: null,
+  unlinked_quantity: null,
+  links: [],
+}
+
+const SELL_TX: Transaction = {
+  id: 'tx2',
+  asset_id: 'a1',
+  type: 'sell',
+  quantity: '5',
+  price_per_unit: '180',
+  fee: '1',
+  currency: 'USD',
+  date: '2024-06-01',
+  broker: null,
+  realized_pnl: '148.50',
+  realized_pnl_pct: '20.33',
+  cost_basis: '730.50',
+  unlinked_quantity: null,
+  links: [],
+}
+
+const SELL_UNLINKED: Transaction = {
+  ...SELL_TX,
+  id: 'tx3',
+  realized_pnl: null,
+  realized_pnl_pct: null,
+  cost_basis: null,
+  unlinked_quantity: '3',
+}
+
+const defaultProps = {
+  transactions: [BUY_TX, SELL_TX],
+  assets: [ASSET],
+  total: 2,
+  hasMore: false,
+  loading: false,
+  onLoadMore: vi.fn(),
+  onUpdateLinks: vi.fn().mockResolvedValue(undefined),
+}
+
+describe('TransactionList', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('renders empty state when no transactions', () => {
+    render(<TransactionList {...defaultProps} transactions={[]} total={0} />)
+    expect(screen.getByText(/Sin transacciones todavía/)).toBeInTheDocument()
+  })
+
+  it('shows asset ticker and buy/sell badge', () => {
+    render(<TransactionList {...defaultProps} />)
+    expect(screen.getAllByText('AAPL').length).toBeGreaterThan(0)
+    expect(screen.getByText('C')).toBeInTheDocument()
+    expect(screen.getByText('V')).toBeInTheDocument()
+  })
+
+  it('shows P&L badge on sell with realized_pnl', () => {
+    render(<TransactionList {...defaultProps} />)
+    expect(screen.getByText(/\+20\.33%/)).toBeInTheDocument()
+  })
+
+  it('shows "sin linkar" badge when unlinked_quantity > 0', () => {
+    render(<TransactionList {...defaultProps} transactions={[SELL_UNLINKED]} total={1} />)
+    expect(screen.getByText(/sin linkar/)).toBeInTheDocument()
+  })
+
+  it('opens LinksModal when "Enlaces" button is clicked', async () => {
+    render(<TransactionList {...defaultProps} />)
+    await userEvent.click(screen.getByText('Enlaces'))
+    expect(screen.getByText('Editar enlaces')).toBeInTheDocument()
+  })
+})

--- a/frontend/abacus/src/components/TransactionList.tsx
+++ b/frontend/abacus/src/components/TransactionList.tsx
@@ -49,7 +49,9 @@ export default function TransactionList({
           {transactions.map(tx => {
             const asset = getAsset(assets, tx.asset_id)
             const isBuy = tx.type === 'buy'
-            const txTotal = Number(tx.quantity) * Number(tx.price_per_unit) + Number(tx.fee)
+            const txTotal = isBuy
+              ? Number(tx.quantity) * Number(tx.price_per_unit) + Number(tx.fee)
+              : Number(tx.quantity) * Number(tx.price_per_unit) - Number(tx.fee)
             const hasPnl = !isBuy && tx.realized_pnl !== null
             const pnlValue = hasPnl ? Number(tx.realized_pnl) : null
             const isPnlPositive = pnlValue !== null && pnlValue >= 0

--- a/frontend/abacus/src/components/TransactionList.tsx
+++ b/frontend/abacus/src/components/TransactionList.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
 import type { Asset, Transaction } from '../types/models'
 import { formatDate, formatCurrency, formatQuantity } from '../utils/format'
+import LinksModal from './LinksModal'
 
 interface Props {
   transactions: Transaction[]
@@ -8,6 +10,7 @@ interface Props {
   hasMore: boolean
   loading: boolean
   onLoadMore: () => void
+  onUpdateLinks: (sellId: string, links: [string, string][]) => Promise<void>
 }
 
 function getAsset(assets: Asset[], id: string): Asset | undefined {
@@ -21,7 +24,10 @@ export default function TransactionList({
   hasMore,
   loading,
   onLoadMore,
+  onUpdateLinks,
 }: Props) {
+  const [linksSell, setLinksSell] = useState<Transaction | null>(null)
+
   if (transactions.length === 0 && !loading) {
     return (
       <div className="bg-slate-800 rounded-2xl p-8 text-center text-slate-400">
@@ -32,81 +38,134 @@ export default function TransactionList({
   }
 
   return (
-    <div className="bg-slate-800 rounded-2xl overflow-hidden">
-      <div className="px-6 py-4 border-b border-slate-700 flex items-center justify-between">
-        <h2 className="text-base font-semibold text-white">Transacciones</h2>
-        <span className="text-xs text-slate-400">{total} total</span>
-      </div>
-
-      <div className="divide-y divide-slate-700">
-        {transactions.map(tx => {
-          const asset = getAsset(assets, tx.asset_id)
-          const isBuy = tx.type === 'buy'
-          const total = Number(tx.quantity) * Number(tx.price_per_unit) + Number(tx.fee)
-
-          return (
-            <div key={tx.id} className="px-6 py-4 flex items-center gap-4">
-              {/* Type badge */}
-              <span
-                className={`shrink-0 text-xs font-semibold px-2 py-0.5 rounded ${
-                  isBuy
-                    ? 'bg-green-900/50 text-green-400'
-                    : 'bg-red-900/50 text-red-400'
-                }`}
-              >
-                {isBuy ? 'C' : 'V'}
-              </span>
-
-              {/* Asset + date */}
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium text-white truncate">
-                  {asset ? (asset.ticker ?? asset.name) : tx.asset_id.slice(0, 8)}
-                  {asset?.ticker && (
-                    <span className="ml-1.5 text-xs text-slate-400 font-normal">{asset.name}</span>
-                  )}
-                </p>
-                <p className="text-xs text-slate-400">
-                  {formatDate(tx.date)}
-                  {tx.broker && ` · ${tx.broker}`}
-                </p>
-              </div>
-
-              {/* Quantity */}
-              <div className="text-right shrink-0">
-                <p className="text-sm text-slate-200">{formatQuantity(tx.quantity)}</p>
-                <p className="text-xs text-slate-400">
-                  {formatCurrency(tx.price_per_unit, tx.currency)}/u
-                </p>
-              </div>
-
-              {/* Total */}
-              <div className="text-right shrink-0 w-24">
-                <p className={`text-sm font-medium ${isBuy ? 'text-red-400' : 'text-green-400'}`}>
-                  {isBuy ? '−' : '+'}
-                  {formatCurrency(total, tx.currency)}
-                </p>
-                {Number(tx.fee) > 0 && (
-                  <p className="text-xs text-slate-500">
-                    com. {formatCurrency(tx.fee, tx.currency)}
-                  </p>
-                )}
-              </div>
-            </div>
-          )
-        })}
-      </div>
-
-      {hasMore && (
-        <div className="px-6 py-4 border-t border-slate-700">
-          <button
-            onClick={onLoadMore}
-            disabled={loading}
-            className="w-full text-sm text-slate-400 hover:text-white disabled:opacity-50 transition-colors"
-          >
-            {loading ? 'Cargando…' : 'Cargar más'}
-          </button>
+    <>
+      <div className="bg-slate-800 rounded-2xl overflow-hidden">
+        <div className="px-6 py-4 border-b border-slate-700 flex items-center justify-between">
+          <h2 className="text-base font-semibold text-white">Transacciones</h2>
+          <span className="text-xs text-slate-400">{total} total</span>
         </div>
+
+        <div className="divide-y divide-slate-700">
+          {transactions.map(tx => {
+            const asset = getAsset(assets, tx.asset_id)
+            const isBuy = tx.type === 'buy'
+            const txTotal = Number(tx.quantity) * Number(tx.price_per_unit) + Number(tx.fee)
+            const hasPnl = !isBuy && tx.realized_pnl !== null
+            const pnlValue = hasPnl ? Number(tx.realized_pnl) : null
+            const isPnlPositive = pnlValue !== null && pnlValue >= 0
+            const hasUnlinked =
+              !isBuy && tx.unlinked_quantity !== null && Number(tx.unlinked_quantity) > 0
+
+            return (
+              <div key={tx.id} className="px-6 py-4 flex items-start gap-4">
+                {/* Type badge */}
+                <span
+                  className={`shrink-0 mt-0.5 text-xs font-semibold px-2 py-0.5 rounded ${
+                    isBuy ? 'bg-green-900/50 text-green-400' : 'bg-red-900/50 text-red-400'
+                  }`}
+                >
+                  {isBuy ? 'C' : 'V'}
+                </span>
+
+                {/* Asset + date */}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-white truncate">
+                    {asset ? (asset.ticker ?? asset.name) : tx.asset_id.slice(0, 8)}
+                    {asset?.ticker && (
+                      <span className="ml-1.5 text-xs text-slate-400 font-normal">
+                        {asset.name}
+                      </span>
+                    )}
+                  </p>
+                  <p className="text-xs text-slate-400">
+                    {formatDate(tx.date)}
+                    {tx.broker && ` · ${tx.broker}`}
+                  </p>
+                  {/* P&L row for sells */}
+                  {(hasPnl || hasUnlinked) && (
+                    <div className="flex items-center gap-2 mt-1">
+                      {hasPnl && (
+                        <span
+                          className={`text-xs font-medium px-1.5 py-0.5 rounded ${
+                            isPnlPositive
+                              ? 'bg-green-900/40 text-green-400'
+                              : 'bg-red-900/40 text-red-400'
+                          }`}
+                        >
+                          {isPnlPositive ? '+' : ''}
+                          {formatCurrency(tx.realized_pnl!, tx.currency)}
+                          {tx.realized_pnl_pct !== null && (
+                            <span className="opacity-75 ml-1">
+                              ({isPnlPositive ? '+' : ''}
+                              {Number(tx.realized_pnl_pct).toFixed(2)}%)
+                            </span>
+                          )}
+                        </span>
+                      )}
+                      {hasUnlinked && (
+                        <span className="text-xs text-amber-500 px-1.5 py-0.5 rounded bg-amber-900/30">
+                          {formatQuantity(tx.unlinked_quantity!)} sin linkar
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                {/* Quantity */}
+                <div className="text-right shrink-0">
+                  <p className="text-sm text-slate-200">{formatQuantity(tx.quantity)}</p>
+                  <p className="text-xs text-slate-400">
+                    {formatCurrency(tx.price_per_unit, tx.currency)}/u
+                  </p>
+                </div>
+
+                {/* Total + links button */}
+                <div className="text-right shrink-0 w-24">
+                  <p
+                    className={`text-sm font-medium ${isBuy ? 'text-red-400' : 'text-green-400'}`}
+                  >
+                    {isBuy ? '−' : '+'}
+                    {formatCurrency(txTotal, tx.currency)}
+                  </p>
+                  {Number(tx.fee) > 0 && (
+                    <p className="text-xs text-slate-500">
+                      com. {formatCurrency(tx.fee, tx.currency)}
+                    </p>
+                  )}
+                  {!isBuy && (
+                    <button
+                      onClick={() => setLinksSell(tx)}
+                      className="mt-1 text-xs text-blue-400 hover:text-blue-300 transition-colors"
+                    >
+                      Enlaces
+                    </button>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        {hasMore && (
+          <div className="px-6 py-4 border-t border-slate-700">
+            <button
+              onClick={onLoadMore}
+              disabled={loading}
+              className="w-full text-sm text-slate-400 hover:text-white disabled:opacity-50 transition-colors"
+            >
+              {loading ? 'Cargando…' : 'Cargar más'}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {linksSell && (
+        <LinksModal
+          sell={linksSell}
+          onSave={onUpdateLinks}
+          onClose={() => setLinksSell(null)}
+        />
       )}
-    </div>
+    </>
   )
 }

--- a/frontend/abacus/src/hooks/useAssetSummary.ts
+++ b/frontend/abacus/src/hooks/useAssetSummary.ts
@@ -1,0 +1,26 @@
+import { useState, useEffect, useCallback } from 'react'
+import { getSummaryByAsset } from '../api/transactions'
+import type { AssetPnLSummary } from '../types/models'
+
+export function useAssetSummary(refreshKey: number) {
+  const [summaries, setSummaries] = useState<AssetPnLSummary[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const fetch = useCallback(async () => {
+    try {
+      setLoading(true)
+      const data = await getSummaryByAsset()
+      setSummaries(data)
+    } catch {
+      // non-critical; fail silently
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetch()
+  }, [fetch, refreshKey])
+
+  return { summaries, loading, refresh: fetch }
+}

--- a/frontend/abacus/src/hooks/useTransactions.ts
+++ b/frontend/abacus/src/hooks/useTransactions.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
-import { listTransactions, createTransaction } from '../api/transactions'
+import { listTransactions, createTransaction, updateSellLinks } from '../api/transactions'
 import type { Transaction, TransactionCreate } from '../types/models'
 
 const PAGE_SIZE = 50
@@ -47,7 +47,15 @@ export function useTransactions() {
     await fetchPage(0)
   }, [fetchPage])
 
+  const updateLinks = useCallback(
+    async (sellId: string, links: [string, string][]): Promise<void> => {
+      await updateSellLinks(sellId, links)
+      await fetchPage(0)
+    },
+    [fetchPage],
+  )
+
   const hasMore = transactions.length < total
 
-  return { transactions, total, loading, error, addTransaction, loadMore, hasMore }
+  return { transactions, total, loading, error, addTransaction, updateLinks, loadMore, hasMore }
 }

--- a/frontend/abacus/src/types/models.ts
+++ b/frontend/abacus/src/types/models.ts
@@ -12,6 +12,14 @@ export interface Asset {
   updated_at: string
 }
 
+export interface TransactionLink {
+  id: string
+  sell_id: string
+  buy_id: string
+  quantity: string
+  created_at: string
+}
+
 export interface Transaction {
   id: string
   asset_id: string
@@ -25,6 +33,34 @@ export interface Transaction {
   notes: string | null
   created_at: string
   updated_at: string
+  // P&L fields — only populated for SELL transactions
+  realized_pnl: string | null
+  realized_pnl_pct: string | null
+  cost_basis: string | null
+  unlinked_quantity: string | null
+  links: TransactionLink[]
+}
+
+export interface AvailableBuy {
+  buy: Transaction
+  qty_available: string
+  qty_linked: string
+}
+
+export interface AvailableBuysResponse {
+  sell: Transaction
+  available_buys: AvailableBuy[]
+}
+
+export interface AssetPnLSummary {
+  asset_id: string
+  asset_ticker: string | null
+  asset_name: string
+  currency: string
+  realized_pnl: string
+  cost_basis: string
+  realized_pnl_pct: string | null
+  sells_count: number
 }
 
 export interface PaginatedTransactions {


### PR DESCRIPTION
## Summary

- Adds a `transaction_links` join table so sells can be associated with specific buy lots (FIFO auto-link on create, manual override via UI)
- Computes net realized P&L per sell (pro-rated fees on both sides) and aggregates it per asset
- Shows colored P&L badge + percentage on each sell row; amber "sin linkar" badge for unmatched quantity
- New **AssetSummary** card above the transaction list with total realized P&L by asset
- New **Links modal** (\"Enlaces\" button on sells) to view and edit buy allocations

## Changes

- **Backend**: `TransactionLink` domain model, `LinkValidationError`, extended repo ports, Alembic migration (`c1d2e3f4a5b6`), `pnl.py` pure computation, `transaction_service.py` FIFO + validation, 4 new API endpoints
- **Frontend**: extended types/models, 3 new API calls, `useAssetSummary` hook, `LinksModal`, `AssetSummary`, updated `TransactionList` + `Dashboard`
- **Tests**: 54 backend (unit + e2e) + 20 frontend — all green

## Test Plan

1. Run `make dev APP=abacus` and open http://localhost:5175
2. Create an asset (e.g. AAPL USD)
3. Add 2 buys: 10 @ 150 fee 1, and 5 @ 160 fee 1
4. Add a sell: 12 @ 180 fee 1 → sell row should show green P&L badge with value and %
5. Click \"Enlaces\" on the sell → modal shows the 2 buys consumed FIFO (10 from first, 2 from second)
6. Adjust quantities manually → Guardar → P&L updates in the list
7. Add a sell of 100 @ 180 on an asset with only a small buy → row shows partial P&L + amber \"sin linkar\" badge
8. Verify AssetSummary card above the list aggregates correctly
9. Run `make backend-shell APP=abacus` → `alembic upgrade head` (confirms table created); `alembic downgrade -1`; `alembic upgrade head`
10. After merge, verify migration runs on Render and https://abacus-6zj.pages.dev shows P&L

🤖 Generated with [Claude Code](https://claude.com/claude-code)