### PR TITLE
feat(mariland): add owner field to piso

### DIFF
--- a/backend/mariland/alembic/versions/0003_add_owner_to_pisos.py
+++ b/backend/mariland/alembic/versions/0003_add_owner_to_pisos.py
@@ -1,0 +1,25 @@
+"""add owner to pisos
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-05-02
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("pisos", sa.Column("owner", sa.String(64), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("pisos", "owner")

--- a/backend/mariland/src/mariland/domain/models/piso.py
+++ b/backend/mariland/src/mariland/domain/models/piso.py
@@ -26,6 +26,7 @@ class Piso(BaseModel):
     contacto_telefono: str | None
     contacto_inmobiliaria: str | None
     estado: str
+    owner: str | None
     extras: dict[str, Any] | None
     notas: str | None
     created_at: datetime

--- a/backend/mariland/src/mariland/infrastructure/persistence/models.py
+++ b/backend/mariland/src/mariland/infrastructure/persistence/models.py
@@ -29,6 +29,7 @@ class PisoModel(Base):
     contacto_telefono: Mapped[str | None] = mapped_column(String(64), nullable=True)
     contacto_inmobiliaria: Mapped[str | None] = mapped_column(String(256), nullable=True)
     estado: Mapped[str] = mapped_column(String(64), nullable=False, default="candidato")
+    owner: Mapped[str | None] = mapped_column(String(64), nullable=True)
     extras: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True, default=dict)
     notas: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/backend/mariland/src/mariland/presentation/schemas/piso_schemas.py
+++ b/backend/mariland/src/mariland/presentation/schemas/piso_schemas.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
+
+VALID_OWNERS = {"Nagore", "Marcos"}
 
 
 class PriceHistoryCreate(BaseModel):
@@ -54,8 +56,16 @@ class PisoCreate(BaseModel):
     contacto_telefono: str | None = None
     contacto_inmobiliaria: str | None = None
     estado: str = "candidato"
+    owner: str | None = None
     extras: dict[str, Any] | None = None
     notas: str | None = None
+
+    @field_validator("owner")
+    @classmethod
+    def validate_owner(cls, v: str | None) -> str | None:
+        if v is not None and v not in VALID_OWNERS:
+            raise ValueError(f"owner must be one of {sorted(VALID_OWNERS)}")
+        return v
 
 
 class PisoUpdate(BaseModel):
@@ -76,8 +86,16 @@ class PisoUpdate(BaseModel):
     contacto_telefono: str | None = None
     contacto_inmobiliaria: str | None = None
     estado: str | None = None
+    owner: str | None = None
     extras: dict[str, Any] | None = None
     notas: str | None = None
+
+    @field_validator("owner")
+    @classmethod
+    def validate_owner(cls, v: str | None) -> str | None:
+        if v is not None and v not in VALID_OWNERS:
+            raise ValueError(f"owner must be one of {sorted(VALID_OWNERS)}")
+        return v
 
 
 class PisoOut(BaseModel):
@@ -99,6 +117,7 @@ class PisoOut(BaseModel):
     contacto_telefono: str | None
     contacto_inmobiliaria: str | None
     estado: str
+    owner: str | None
     extras: dict[str, Any] | None
     notas: str | None
     created_at: datetime

--- a/backend/mariland/tests/conftest.py
+++ b/backend/mariland/tests/conftest.py
@@ -38,6 +38,7 @@ def make_piso(**kwargs: Any) -> Piso:
         "contacto_telefono": None,
         "contacto_inmobiliaria": None,
         "estado": "candidato",
+        "owner": None,
         "extras": None,
         "notas": None,
         "created_at": now,

--- a/backend/mariland/tests/e2e/test_pisos_api.py
+++ b/backend/mariland/tests/e2e/test_pisos_api.py
@@ -187,3 +187,44 @@ async def test_piso_out_contains_imagen_url_null(
 
     assert response.status_code == 200
     assert response.json()["imagen_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_piso_with_owner(
+    async_client: AsyncClient, mock_piso_svc: AsyncMock
+) -> None:
+    piso = make_piso(id=1, owner="Marcos")
+    mock_piso_svc.create_piso.return_value = piso
+
+    response = await async_client.post(
+        "/api/pisos/",
+        json={"estado": "candidato", "owner": "Marcos"},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["owner"] == "Marcos"
+
+
+@pytest.mark.asyncio
+async def test_piso_out_contains_owner_null(
+    async_client: AsyncClient, mock_piso_svc: AsyncMock
+) -> None:
+    piso = make_piso(id=3, owner=None)
+    mock_piso_svc.get_piso.return_value = piso
+
+    response = await async_client.get("/api/pisos/3")
+
+    assert response.status_code == 200
+    assert response.json()["owner"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_piso_invalid_owner(
+    async_client: AsyncClient, mock_piso_svc: AsyncMock
+) -> None:
+    response = await async_client.post(
+        "/api/pisos/",
+        json={"estado": "candidato", "owner": "OtroNombre"},
+    )
+
+    assert response.status_code == 422

--- a/frontend/mariland/.claude/plans/add-owner-to-piso-mariland.md
+++ b/frontend/mariland/.claude/plans/add-owner-to-piso-mariland.md
@@ -1,0 +1,17 @@
+# Add owner field to Piso
+
+Campo `owner` para indicar quién se encarga de contactar con la inmobiliaria y agendar la visita. Valores posibles: "Nagore", "Marcos" (o null).
+
+## Backend
+
+- [x] Crear migración `0003_add_owner_to_pisos.py`
+- [x] Añadir `owner` al modelo SQLAlchemy (`infrastructure/persistence/models.py`)
+- [x] Añadir `owner` al modelo de dominio (`domain/models/piso.py`)
+- [x] Añadir `owner` a los schemas Pydantic (`presentation/schemas/piso_schemas.py`) con validación
+- [x] Añadir `owner: None` al fixture `make_piso` en `tests/conftest.py`
+
+## Frontend
+
+- [x] Añadir `owner` a la interfaz `Piso` y `PisoCreate` en `types/piso.ts`
+- [x] Añadir select dropdown de owner en `PisoForm.tsx`
+- [x] Mostrar owner en `PisoCard.tsx`

--- a/frontend/mariland/src/App.tsx
+++ b/frontend/mariland/src/App.tsx
@@ -127,6 +127,7 @@ export default function App() {
               onPrices={() => setPricePiso(piso)}
               onExtras={() => setExtrasPiso(piso)}
               onEstadoChange={(id, estado) => updatePiso(id, { estado })}
+              onOwnerChange={(id, owner) => updatePiso(id, { owner })}
             />
           ))}
         </div>

--- a/frontend/mariland/src/components/OwnerDropdown.tsx
+++ b/frontend/mariland/src/components/OwnerDropdown.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from 'react'
+
+const OWNERS = ['Nagore', 'Marcos']
+
+const OWNER_COLORS: Record<string, string> = {
+  Nagore: 'bg-purple-100 text-purple-700',
+  Marcos: 'bg-indigo-100 text-indigo-700',
+}
+
+interface OwnerDropdownProps {
+  pisoId: number
+  owner: string | null
+  onOwnerChange: (id: number, owner: string | null) => void
+}
+
+export default function OwnerDropdown({ pisoId, owner, onOwnerChange }: OwnerDropdownProps) {
+  const [open, setOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  async function handleSelect(nuevoOwner: string | null) {
+    if (nuevoOwner === owner) {
+      setOpen(false)
+      return
+    }
+    setOpen(false)
+    setSaving(true)
+    try {
+      await onOwnerChange(pisoId, nuevoOwner)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        disabled={saving}
+        className={`shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium transition ${owner ? (OWNER_COLORS[owner] ?? 'bg-gray-100 text-gray-600') : 'bg-gray-100 text-gray-400'} ${saving ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:ring-2 hover:ring-offset-1 hover:ring-gray-300'}`}
+      >
+        {owner ?? '—'}
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 min-w-[120px] rounded-lg border border-gray-200 bg-white py-1 shadow-lg">
+          {OWNERS.map((o) => (
+            <button
+              key={o}
+              type="button"
+              onClick={() => handleSelect(o)}
+              className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-gray-50 ${o === owner ? 'font-semibold' : ''}`}
+            >
+              <span className={`rounded-full px-2 py-0.5 ${OWNER_COLORS[o]}`}>{o}</span>
+              {o === owner && <span className="ml-auto text-gray-400">✓</span>}
+            </button>
+          ))}
+          {owner && (
+            <button
+              type="button"
+              onClick={() => handleSelect(null)}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-gray-400 hover:bg-gray-50"
+            >
+              Quitar
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/mariland/src/components/PisoCard.tsx
+++ b/frontend/mariland/src/components/PisoCard.tsx
@@ -117,6 +117,11 @@ export default function PisoCard({ piso, onEdit, onDelete, onComments, onPrices,
           )}
         </div>
       )}
+      {piso.owner && (
+        <div className="mt-1 text-xs text-gray-400">
+          👤 <span className="font-medium text-gray-500">{piso.owner}</span> gestiona el contacto
+        </div>
+      )}
       <div className="mt-2 flex gap-3 text-xs text-gray-400">
         {piso.comments.length > 0 && <span>💬 {piso.comments.length}</span>}
         {piso.price_history.length > 0 && <span>📊 {piso.price_history.length} precios</span>}

--- a/frontend/mariland/src/components/PisoCard.tsx
+++ b/frontend/mariland/src/components/PisoCard.tsx
@@ -3,6 +3,7 @@ import type { Piso, PriceHistory } from '../types/piso'
 import ActionMenu from './ActionMenu'
 import EstadoDropdown from './EstadoDropdown'
 import ImagenModal from './ImagenModal'
+import OwnerDropdown from './OwnerDropdown'
 
 const CERT_COLORS: Record<string, string> = {
   A: 'bg-green-600', B: 'bg-green-400', C: 'bg-yellow-400',
@@ -32,9 +33,10 @@ interface PisoCardProps {
   onPrices: () => void
   onExtras: () => void
   onEstadoChange: (id: number, estado: string) => void
+  onOwnerChange: (id: number, owner: string | null) => void
 }
 
-export default function PisoCard({ piso, onEdit, onDelete, onComments, onPrices, onExtras, onEstadoChange }: PisoCardProps) {
+export default function PisoCard({ piso, onEdit, onDelete, onComments, onPrices, onExtras, onEstadoChange, onOwnerChange }: PisoCardProps) {
   const [showImagenModal, setShowImagenModal] = useState(false)
   const variation = priceVariation(piso)
   const precioM2 = piso.precio && piso.metros ? Math.round(piso.precio / piso.metros) : null
@@ -69,6 +71,7 @@ export default function PisoCard({ piso, onEdit, onDelete, onComments, onPrices,
               {piso.certificacion_energetica}
             </span>
           )}
+          <OwnerDropdown pisoId={piso.id} owner={piso.owner} onOwnerChange={onOwnerChange} />
           <EstadoDropdown pisoId={piso.id} estado={piso.estado} onEstadoChange={onEstadoChange} />
           <ActionMenu
             onEdit={onEdit}
@@ -115,11 +118,6 @@ export default function PisoCard({ piso, onEdit, onDelete, onComments, onPrices,
               📞 {piso.contacto_telefono}
             </a>
           )}
-        </div>
-      )}
-      {piso.owner && (
-        <div className="mt-1 text-xs text-gray-400">
-          👤 <span className="font-medium text-gray-500">{piso.owner}</span> gestiona el contacto
         </div>
       )}
       <div className="mt-2 flex gap-3 text-xs text-gray-400">

--- a/frontend/mariland/src/components/PisoForm.tsx
+++ b/frontend/mariland/src/components/PisoForm.tsx
@@ -4,6 +4,7 @@ import { ESTADOS } from '../utils/estadoUtils'
 import Modal from './Modal'
 const CERT_ENERGETICA = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'en trámite', 'exento']
 const ORIENTACIONES = ['Norte', 'Noreste', 'Este', 'Sureste', 'Sur', 'Suroeste', 'Oeste', 'Noroeste']
+const OWNERS = ['Nagore', 'Marcos']
 const BARRIOS = [
   'Centre',
   'Marianao',
@@ -33,6 +34,7 @@ type FormState = {
   contacto_telefono: string
   contacto_inmobiliaria: string
   estado: string
+  owner: string
   notas: string
 }
 
@@ -61,6 +63,7 @@ export default function PisoForm({ piso, onSave, onClose }: PisoFormProps) {
     contacto_telefono: piso?.contacto_telefono ?? '',
     contacto_inmobiliaria: piso?.contacto_inmobiliaria ?? '',
     estado: piso?.estado ?? 'candidato',
+    owner: piso?.owner ?? '',
     notas: piso?.notas ?? '',
   })
   const [loading, setLoading] = useState(false)
@@ -89,6 +92,7 @@ export default function PisoForm({ piso, onSave, onClose }: PisoFormProps) {
         contacto_nombre: form.contacto_nombre || null,
         contacto_telefono: form.contacto_telefono || null,
         contacto_inmobiliaria: form.contacto_inmobiliaria || null,
+        owner: form.owner || null,
         notas: form.notas || null,
       }
       await onSave(data)
@@ -196,6 +200,14 @@ export default function PisoForm({ piso, onSave, onClose }: PisoFormProps) {
         </div>
         <div className="border-t border-gray-100 pt-4">
           <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-400">Contacto</p>
+          <div className="mb-3">
+            <label className="mb-1 block text-sm font-medium text-gray-700">Responsable de contacto</label>
+            <select value={form.owner} onChange={set('owner')}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none bg-white">
+              <option value="">—</option>
+              {OWNERS.map((o) => <option key={o} value={o}>{o}</option>)}
+            </select>
+          </div>
           <div className="grid grid-cols-2 gap-3">
             <div>
               <label className="mb-1 block text-sm font-medium text-gray-700">Nombre</label>

--- a/frontend/mariland/src/test/ImportFromUrlModal.test.tsx
+++ b/frontend/mariland/src/test/ImportFromUrlModal.test.tsx
@@ -24,6 +24,7 @@ const basePiso: Piso = {
   contacto_telefono: null,
   contacto_inmobiliaria: null,
   estado: 'candidato',
+  owner: null,
   extras: null,
   notas: null,
   created_at: '2026-01-01T00:00:00Z',

--- a/frontend/mariland/src/test/PisoCard.test.tsx
+++ b/frontend/mariland/src/test/PisoCard.test.tsx
@@ -23,6 +23,7 @@ const basePiso: Piso = {
   contacto_telefono: null,
   contacto_inmobiliaria: null,
   estado: 'candidato',
+  owner: null,
   extras: null,
   notas: null,
   created_at: '2026-01-01T00:00:00Z',

--- a/frontend/mariland/src/test/PisoCard.test.tsx
+++ b/frontend/mariland/src/test/PisoCard.test.tsx
@@ -41,6 +41,7 @@ function renderCard(overrides: Partial<Piso> = {}) {
     onPrices: vi.fn(),
     onExtras: vi.fn(),
     onEstadoChange: vi.fn(),
+    onOwnerChange: vi.fn(),
   }
   render(<PisoCard {...props} />)
   return props

--- a/frontend/mariland/src/test/Stats.test.tsx
+++ b/frontend/mariland/src/test/Stats.test.tsx
@@ -23,6 +23,7 @@ function makePiso(overrides: Partial<Piso> = {}): Piso {
     contacto_telefono: null,
     contacto_inmobiliaria: null,
     estado: 'candidato',
+    owner: null,
     extras: null,
     notas: null,
     created_at: '2026-01-01T00:00:00Z',

--- a/frontend/mariland/src/test/usePisos.test.ts
+++ b/frontend/mariland/src/test/usePisos.test.ts
@@ -23,6 +23,7 @@ const basePiso: Piso = {
   contacto_telefono: null,
   contacto_inmobiliaria: null,
   estado: 'candidato',
+  owner: null,
   extras: null,
   notas: null,
   created_at: '2026-01-01T00:00:00Z',

--- a/frontend/mariland/src/types/piso.ts
+++ b/frontend/mariland/src/types/piso.ts
@@ -32,6 +32,7 @@ export interface Piso {
   contacto_telefono: string | null
   contacto_inmobiliaria: string | null
   estado: string
+  owner: string | null
   extras: Record<string, boolean> | null
   notas: string | null
   created_at: string
@@ -58,6 +59,7 @@ export interface PisoCreate {
   contacto_telefono?: string | null
   contacto_inmobiliaria?: string | null
   estado?: string
+  owner?: string | null
   extras?: Record<string, boolean> | null
   notas?: string | null
 }


### PR DESCRIPTION
## Summary
- Añade campo `owner` (nullable, valores: \"Nagore\" | \"Marcos\") para indicar quién gestiona el contacto con la inmobiliaria y agenda la visita
- Backend: migración Alembic, modelo SQLAlchemy, dominio y schemas Pydantic con validación
- Frontend: dropdown en el formulario y visualización en la card

## Changes
- `0003_add_owner_to_pisos.py` — nueva migración
- `piso_schemas.py` — validación Pydantic (rechaza valores fuera de Nagore/Marcos)
- `PisoForm.tsx` — select dropdown en la sección Contacto
- `PisoCard.tsx` — muestra el owner si está definido

🤖 Generated with [Claude Code](https://claude.com/claude-code)